### PR TITLE
Hard line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Luacheck](https://img.shields.io/github/workflow/status/Omikhleia/markdown.sile/Luacheck?label=Luacheck&logo=Lua)](https://github.com/Omikhleia/markdown.sile/actions?workflow=Luacheck)
 [![Luarocks](https://img.shields.io/luarocks/v/Omikhleia/markdown.sile?label=Luarocks&logo=Lua)](https://luarocks.org/modules/Omikhleia/markdown.sile)
 
-_EARLY PRE-RELEASE_
-
 This collection of modules for the [SILE](https://github.com/sile-typesetter/sile) typesetting
 system provides a complete redesign of the native Markdown support for SILE, with
 a great set of Pandoc-like extensions and plenty of extra goodies.
@@ -28,7 +26,7 @@ luarocks --lua-version 5.4 install --server=https://luarocks.org/dev markdown.si
 (Adapt to your version of Lua, if need be, and refer to the SILE manual for more
 detailed 3rd-party package installation information.)
 
-## Usage
+## Usage (native Markdown package)
 
 From command line:
 
@@ -36,7 +34,7 @@ From command line:
 sile -u inputters.markdown somefile.md
 ```
 
-From documents (e.g. here in SILE language)
+Or from documents (e.g. here in SILE language):
 
 ```
 \use[module=packages.markdown]
@@ -47,9 +45,87 @@ Other possibilities exists (such as setting `format=markdown` on the `\include` 
 cannot be one of the supported variants, etc.). Refer to the SILE manual for more details on inputters and their
 usage.
 
-The "example" documentation/showcase in this repository additionaly requires the `autodoc` package, so you may
-generate a PDF from it with:
+Including raw Markdown content from within a SILE document is also possible:
+
+```
+\begin[type=markdown]{raw}
+Some Markdown content
+\end{raw}
+```
+
+## Usage (Pandoc AST alternative package)
+
+_Prerequisites:_ The [LuaJSON](https://github.com/harningt/luajson) module must be
+installed and available to your SILE environment. This topic is not covered here.
+
+First, using the appropriate version of Pandoc, convert your file to a JSON AST:
+
+```
+pandoc -t json somefile.md -f markdown -o somefile.pandoc
+```
+
+Then, from command line:
+
+```
+sile -u inputters.pandocast somefile.pandoc
+```
+
+Or from documents:
+
+```
+\use[module=packages.pandocast]
+\include[src=somefile.pandoc]
+```
+
+## Generating the documentation
+
+
+The "example" documentation/showcase in this repository additionaly requires the `autodoc` package, so you
+may generate a PDF from it with as follows:
 
 ```
 sile -u inputters.markdown -u packages.autodoc examples/sile-and-markdown.md
 ```
+
+Or, for even best results (in this writer's biased opinion), provided you have installed the
+[resilient](https://github.com/Omikhleia/resilient.sile) collection of classes and packages:
+
+```
+sile examples/sile-and-markdown-manual.sil
+```
+
+## Supported features
+
+This is but an overview. For more details, please refer to the provided example Markdown document,
+which also serves as documentation, showcase and reference guide.
+
+- Standard Mardown typesetting (italic, bold, code, etc.)
+- Smart typography (quotes, apostrophes, ellipsis, dashes, etc.)
+- Headers and header attributes
+- Horizontal rules
+- Images (and image attributes, e.g. dimensions)
+- Strikeout (a.k.a. deletions)
+- Subscript and superscript
+- Footnotes (both regular and inline syntax support)
+- Fenced code blocks (with attributes)
+- Bracketed spans and fenced divs (with provisions for language change, custom styles, etc.)
+- Underlines
+- Small caps
+- Links
+- Lists
+  - Standard ordered lists and bullet lists
+  - Fancy lists
+  - Task lists (GFM-like)
+  - Definition lists
+- Pipe tables (and table captions)
+- Line blocks (with enhanced provision for poetry)
+- Hard line breaks
+- Raw attributes (escaping to inline SILE or Lua scripting)
+
+## License
+
+All SILE-related code and samples in this repository are released under the MIT License, (c) 2022 Omikhleia.
+
+A vendored (subset) of the [lunamark](https://github.com/jgm/lunamark) Lua parsing library is
+distributed alongside. All corresponding files (in the `lua-libraries` folder) are released under
+the MIT license, (c) 2009 John MacFarlane, _et al._

--- a/examples/sile-and-markdown-manual.sil
+++ b/examples/sile-and-markdown-manual.sil
@@ -1,0 +1,40 @@
+\begin[class=resilient.book]{document}
+\use[module=packages.autodoc]
+\use[module=packages.font-fallback]
+\use[module=packages.framebox]
+\use[module=packages.markdown]
+\use[module=packages.resilient.poetry]
+\font[family=Libertinus Serif]
+\font:add-fallback[family=Symbola, size=8pt]
+\language[main=en]
+\footnote:rule
+%
+% Standard documentation/showcase in Markdown
+\include[src=sile-and-markdown.md]
+%
+% Now let's try something very cool...
+% - Quick and dirty definition of a new custom style...
+%   (using out still experimental "resilient" styling feature)
+\lua{
+SILE.scratch.styles.alignments["framed"] = "customframe"
+}
+\define[command=customframe]{\center{\roughbox[bordercolor=#59b24c,
+  fillcolor=220,padding=15pt, enlarge=true]{\parbox[width=90%lw, minimize=true]{\process}}}}
+\style:define[name=FramedPara]{
+  \paragraph[skipbefore=bigskip, skipafter=bigskip, align=framed]
+}
+\define[command=FramedPara]{\style:apply:paragraph[name=FramedPara]{\process}}
+% - And let's process some inline Markdown using it...
+
+\begin[type=markdown]{raw}
+
+::: {custom-style=FramedPara}
+Thanks, my gentle reader, for having read this document so far.
+So, what _should_ we do now? It's maybe up to **you** now, to provide feedback
+and help pushing all these components farther!
+:::
+
+Oh yay!^[Custom styles are pretty neat, aren't they?]
+
+\end{raw}
+\end{document}

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -56,6 +56,11 @@ produce an horizontal rule.
 
 ***
 
+Hard line breaks...\
+...are supported too, either using the standard "invisible" method from Markdown (i.e. two trailing
+spaces at the end of a line) or a backslash-escaped newline (i.e. a backslash occurring at the
+end of a line, as in the corresponding default Pandoc extension).
+
 Several Pandoc-like extensions to Markdown are supported.
 Notably, the converter comes by default with smart typography enabled: three dashes (`---`) in an
 inline text sequence are converted to an em-dash (---), two dashes (`--`)

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -42,6 +42,14 @@ to the basics here.
 \include[src=somefile.md]
 ```
 
+Including raw Markdown content from within a SILE document is also possible:
+
+```
+\begin[type=markdown]{raw}
+Some Markdown content
+\end{raw}
+```
+
 ### Basic typesetting {#basic-typesetting}
 
 As it can be seen here, sectioning obviously works^[With a small caveat. The package maps heading
@@ -61,7 +69,7 @@ Hard line breaks...\
 spaces at the end of a line) or a backslash-escaped newline (i.e. a backslash occurring at the
 end of a line, as in the corresponding default Pandoc extension).
 
-Several Pandoc-like extensions to Markdown are supported.
+Several Pandoc-like extensions to Markdown are also supported.
 Notably, the converter comes by default with smart typography enabled: three dashes (`---`) in an
 inline text sequence are converted to an em-dash (---), two dashes (`--`)
 to an en-dash useful for ranges (ex., "it's at pages 12--14"), and three dots
@@ -179,7 +187,7 @@ attribute.
 This is, as a matter of fact, the same syntax as proposed by Pandoc, for instance, in
 its **docx** writer, to specify a specific, possibly user-defined, custom style name (in that
 case, a Word style, obviously). So yes, if you had a Pandoc-Markdown document styled for Word,
-you might consider switching to SILE is an option!
+you might consider that switching to SILE is a viable option!
 
 If such a named style exists, it is applied. Erm. What does it mean? Well, in the default
 implementation, if there is a corresponding SILE command by that name, the converter invokes
@@ -192,7 +200,7 @@ This is SILE at its best.
 :::
 
 And some inline [message]{custom-style="strong"}, marked as "strong". That's a fairly
-contrived way to obtain a bold text, but you get the underlying idea.
+contrived way to obtain a bold text, but you get the underlying general idea.
 
 This logic is implemented in the `\autodoc:command{\markdown:custom-style:hook}`{=sile}
 command. Package or class designers may override this hook to support any
@@ -228,22 +236,6 @@ Regarding captioned tables, there's again a catch. If your class or previously l
 provide a `captioned-table` environment, it will be wrapped around the table (and it is then assumed to
 take care of a `\caption` content, i.e. to extract and display it appropriately).  Otherwise,
 the converter uses its own fallback method.
-
-### Code blocks
-
-Verbatim code and "fenced code blocks" work:
-
-```lua
-function fib (n)
-  -- Fibonacci numbers
-  if n < 2 then return 1 end
-  return fib(n - 2) + fib(n - 1)
-end
-```
-
-As show above, code blocks marked as being in Lua (either with the `lua` information string or the `.lua` class
-specifier) are syntax-highlighted. This is a naive approach, until the converter possibly supports a more general
-solution.
 
 ### Line blocks
 
@@ -304,6 +296,22 @@ with headers, the `.unnumbered` class specifier is also supported.], `start` and
 
 :::
 ~~~
+
+### Code blocks
+
+Verbatim code and "fenced code blocks" work:
+
+```lua
+function fib (n)
+  -- Fibonacci numbers
+  if n < 2 then return 1 end
+  return fib(n - 2) + fib(n - 1)
+end
+```
+
+As show above, code blocks marked as being in Lua (either with the `lua` information string or the `.lua` class
+specifier) are syntax-highlighted. This is a naive approach, until the converter possibly supports a more general
+solution.
 
 ### Raw blocks
 
@@ -394,7 +402,9 @@ There is a small _caveat_, though: one must use a version of Pandoc which genera
 an AST compatible with our parser ("inputter"). While the Pandoc AST is somewhat stable,
 it may change when new features are introduced in the software.
 
-### Using a Pandoc SILE writer and the pandoc package
+### Other Pandoc-based solutions
+
+#### Using a Pandoc SILE writer and the pandoc package {-}
 
 There is no official SILE writer for Pandoc yet, but some efforts have been done in that direction.
 It therefore requires installing a Pandoc fork^[<https://github.com/alerque/pandoc/commits/sile4>],
@@ -403,7 +413,7 @@ which is not merged upstream at this date.
 You then need to use the SILE `\autodoc:package{pandoc}`{=sile} package, which provides the
 required command mappings between the Pandoc-to-SILE writer and the rest of the software.
 
-### Using a Pandoc "custom writer" in Lua
+#### Using a Pandoc "custom writer" in Lua {-}
 
 Pandoc also supports "custom writers" developed in Lua^[<https://pandoc.org/custom-writers.html>].
 

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -79,6 +79,7 @@ local function SileAstWriter (options)
   writer.blockquote = simpleCommandWrapper("markdown:internal:blockquote")
   writer.verbatim = simpleCommandWrapper("verbatim")
   writer.listitem = simpleCommandWrapper("item")
+  writer.linebreak = simpleCommandWrapper("cr")
 
   -- Special case for hrule (simple too, but arguments from lunamark has to be ignored)
   writer.hrule = function () return utils.createCommand("fullrule") end
@@ -328,6 +329,7 @@ function inputter.parse (_, doc)
     pipe_tables = true,
     header_attributes = true,
     line_blocks = true,
+    escaped_line_breaks = true,
   })
   local tree = parse(doc)
   -- The Markdown parsing returns a string or a SILE AST table.

--- a/packages/markdown/init.lua
+++ b/packages/markdown/init.lua
@@ -16,6 +16,14 @@ function package:_init (_)
   local _ = SILE.inputters.markdown
 end
 
+function package:registerRawHandlers ()
+
+  self.class:registerRawHandler("markdown", function(_, content)
+    SILE.processString(content[1], "markdown", nil, {})
+  end)
+
+end
+
 package.documentation = [[\begin{document}
 The \autodoc:package{markdown} package allows you to use Markdown, with plenty of additional
 features and extensions, as your alternative format of choice for documents —without leaving


### PR DESCRIPTION
Native markdown support for:
- Standard hard line breaks (two trailing spaces at end of line)
- Pandoc-like escaped line breaks (a blackslash at end of line).

This PR also includes
- Raw (inline) Markdown support in SILE documents
- Better docs.