### PR TITLE
fix: too restrictive native Markdown attribute parsing

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -205,7 +205,7 @@ end
 
 Code blocks marked as being in the Graphviz DOT language are rendered as images.
 
-{width=2cm layout=twopi}
+{width="3.5cm" layout=twopi}
 ```dot
 graph {
   node [fillcolor="lightskyblue:darkcyan" style=filled gradientangle=270]

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -283,7 +283,7 @@ Notably ![](./examples/manicule.svg){height=0.9em} SVG is supported too (`.svg`)
 here with a "manicule" in the format.
 Files in Graphviz DOT graph language (`.dot`) are supported and rendered as images too.
 
-![The **markdown.sile** ecosystem (simplified).](./markdown-sile-schema.dot "A graph"){width=12cm}
+![The **markdown.sile** ecosystem (simplified).](./markdown-sile-schema.dot "A graph"){width="80%fw"}
 
 ### Maths
 

--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -151,10 +151,17 @@ parsers.indented_blocks = function(bl)
 end
 
 -- Attributes list as in Pandoc {#id .class .class-other key=value key2="value 2"}
+-- N.B. For attribute values, Pandoc may possibly accept more things than us here,
+-- the details may have to be checked.
 parsers.identifier  = parsers.letter
                       * (parsers.alphanumeric + S("_-"))^0
-parsers.attrvalue   = (parsers.dquote * C((parsers.alphanumeric + S("._- "))^1) * parsers.dquote)
-                      + C((parsers.alphanumeric + S("._-"))^1)
+parsers.attrvalue   = (parsers.dquote
+                      * C((parsers.anyescaped - parsers.dquote)^0)
+                      * parsers.dquote)
+                    + (parsers.squote
+                      * C((parsers.anyescaped - parsers.squote)^0)
+                      * parsers.squote)
+                    + C((parsers.anyescaped - parsers.dquote - parsers.space - P("}"))^1)
 
 parsers.attrpair    = Cg(C((parsers.identifier)^1)
                       * parsers.optionalspace * parsers.equal * parsers.optionalspace


### PR DESCRIPTION
E.g. it was not allowing characters found in usual SILE dimensions, such as "50%lw" or "3.5cm".

Closes #49 

This is kind of workaround here on our vendored lunamark copy - the issue is reported upstream to it, but I am not sure I read the Pandoc haskell code well enough for a proper (= complete and safe) resolution.