### PR TITLE
feat: propogate .unnumbered and .notoc on captioned elements

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -167,7 +167,8 @@ $$`\pi=\sum_{k=0}^\infty\frac{1}{16^k}(\frac{4}{8k+1} − \frac{2}{8k+4} − \fr
 {#djot-tables}
 #### Tables
 
-Djot supports the "pipe table" syntax, with its own way for marking the (optional) caption.
+Djot supports the "pipe table" syntax, with its own way for marking the (optional)
+caption.[^djot-numbered-caption]
 
 | Right | Left | Default | Center |
 |------:|:-----|---------|:------:|
@@ -175,6 +176,10 @@ Djot supports the "pipe table" syntax, with its own way for marking the (optiona
 |  123  |  123 |   123   |   123  |
 
 ^ Demonstration of a pipe table.
+
+[^djot-numbered-caption]: When using the **resilient** classes, the caption will be numbered by
+default, and added to the list of tables. Specify `.unnumbered`, and `.notoc` respectively, as
+table attributes, if you do not want it.
 
 #### Basic links
 

--- a/examples/sile-and-markdown-manual.sil
+++ b/examples/sile-and-markdown-manual.sil
@@ -46,7 +46,7 @@ Showcase Document
 \hbox{}
 \vfill
 
-\noindent{}© 2022 Didier Willis.
+\noindent{}© 2022–2023 Didier Willis.
 
 \noindent{}This material may be distributed only subject to the terms and conditions set forth in the
 Creative Commons Attribution, Share-Alike License,
@@ -79,14 +79,15 @@ class:registerStyle("FramedPara", {}, {
 \define[command=FramedPara]{\style:apply:paragraph[name=FramedPara]{\process}}
 % - Some other packages
 \lua{
-SILE.registerCommand("Ean13", function (_, content)
+local class = SILE.documentState.documentClass
+class:registerCommand("Ean13", function (_, content)
   local code = content[1]
   -- Markdown parser may interpret a dash between digits as smart typography for en-dash.
   -- Let's remove those.
   code = code:gsub("–","")
   SILE.call("ean13", { code = code })
 end)
-SILE.registerCommand("Initial", function (_, content)
+class:registerCommand("Initial", function (_, content)
   local letter = content[1]
   SILE.call("dropcap", { lines = 3, family = "Zallman Caps", join = true }, { letter })
 end)

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -281,8 +281,8 @@ Otherwise, the converter uses its own fallback method.
 
 Besides regular image files, a few specific file extensions are also recognized and
 processed appropriately.
-Notably ![](./examples/manicule.svg){height=0.9em} SVG is supported too (`.svg`), as demonstrated
-here with a "manicule" in the format.
+Notably ![](./examples/manicule.svg){height=0.6bs} SVG is supported too (`.svg`), as demonstrated
+here with a "manicule" in that format.
 Files in Graphviz DOT graph language (`.dot`) are supported and rendered as images too.
 
 ![The **markdown.sile** ecosystem (simplified).](./markdown-sile-schema.dot "A graph"){width="75%fw"}

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -273,8 +273,10 @@ image syntax ---Note that any unit system supported by SILE is accepted.
 
 An image with nonempty caption (i.e. "alternate" text), occurring alone by itself in a paragraph,
 will be rendered as a figure with a caption. If your class or previously loaded packages
-provide a `captioned-figure` environment, it will be wrapped around the image (and it is then assumed to
-take care of a `\caption` content, i.e. to extract and display it appropriately).
+provide a `captioned-figure` environment, it will be wrapped around the image (and it is then assumed to take care of a `\caption` content, i.e. to extract and display it
+appropriately).^[When using the **resilient** classes, the caption will be numbered by
+default, and added to the list of figures. Specify `.unnumbered`, and `.notoc` respectively,
+if you do not want it.]
 Otherwise, the converter uses its own fallback method.
 
 Besides regular image files, a few specific file extensions are also recognized and
@@ -283,7 +285,7 @@ Notably ![](./examples/manicule.svg){height=0.9em} SVG is supported too (`.svg`)
 here with a "manicule" in the format.
 Files in Graphviz DOT graph language (`.dot`) are supported and rendered as images too.
 
-![The **markdown.sile** ecosystem (simplified).](./markdown-sile-schema.dot "A graph"){width="80%fw"}
+![The **markdown.sile** ecosystem (simplified).](./markdown-sile-schema.dot "A graph"){width="75%fw"}
 
 ### Maths
 

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -117,6 +117,7 @@ function Renderer.code_block (_, node)
 end
 
 function Renderer:table (node)
+  local options = node.attr or {}
   if not node.c then
     SU.error("Table without content (should not occur)")
   end
@@ -152,7 +153,7 @@ function Renderer:table (node)
     ptable,
     utils.createCommand("caption", {}, caption)
   }
-  return utils.createStructuredCommand("markdown:internal:captioned-table", {}, captioned)
+  return utils.createStructuredCommand("markdown:internal:captioned-table", options, captioned)
 end
 
 function Renderer:row (node)

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -180,7 +180,8 @@ function package:registerCommands ()
         -- use the caption numbering)
         local id = image.options.id
         image.options.id = nil
-        SILE.call("markdown:internal:captioned-figure", {}, {
+        -- We also propagate image options to the englobing environment
+        SILE.call("markdown:internal:captioned-figure", image.options, {
           image,
           utils.createCommand("caption", {}, {
             utils.createCommand("label", { marker = id }),
@@ -188,7 +189,8 @@ function package:registerCommands ()
           }),
         })
       else
-        SILE.call("markdown:internal:captioned-figure", {}, {
+        -- We also propagate image options to the englobing environment
+        SILE.call("markdown:internal:captioned-figure", image.options, {
           image,
           utils.createCommand("caption", {}, caption),
         })
@@ -483,7 +485,7 @@ function package:registerCommands ()
     end
   end, "Block quote in Markdown (internal)")
 
-  self:registerCommand("markdown:internal:captioned-table", function (_, content)
+  self:registerCommand("markdown:internal:captioned-table", function (options, content)
     -- Makes it easier for class/packages to provide their own captioned-table
     -- environment if they want to do so (possibly with more features,
     -- e.g. managing list of tables, numbering and cross-references etc.),
@@ -491,11 +493,18 @@ function package:registerCommands ()
     if not SILE.Commands["captioned-table"] then
       SILE.call("markdown:fallback:captioned-table", {}, content)
     else
-      SILE.call("captioned-table", {}, content)
+      local tableopts = {}
+      if hasClass(options, "unnumbered") then
+        tableopts.numbering = false
+      end
+      if hasClass(options, "notoc") then
+        tableopts.toc = false
+      end
+      SILE.call("captioned-table", tableopts, content)
     end
   end, "Captioned table in Markdown (internal)")
 
-  self:registerCommand("markdown:internal:captioned-figure", function (_, content)
+  self:registerCommand("markdown:internal:captioned-figure", function (options, content)
     -- Makes it easier for class/packages to provide their own captioned-figure
     -- environment if they want to do so (possibly with more features,
     -- e.g. managing list of tables, numbering and cross-references etc.),
@@ -503,9 +512,16 @@ function package:registerCommands ()
     if not SILE.Commands["captioned-figure"] then
       SILE.call("markdown:fallback:captioned-figure", {}, content)
     else
-      SILE.call("captioned-figure", {}, content)
+      local figopts = {}
+      if hasClass(options, "unnumbered") then
+        figopts.numbering = false
+      end
+      if hasClass(options, "notoc") then
+        figopts.toc = false
+      end
+      SILE.call("captioned-figure", figopts, content)
     end
-  end, "Captioned table in Markdown (internal)")
+  end, "Captioned figure in Markdown (internal)")
 
   self:registerCommand("markdown:internal:codeblock", function (options, content)
     if hasClass(options, "dot") and SU.boolean(options.render, true) then
@@ -658,7 +674,7 @@ function package:registerCommands ()
       end
     end)
     SILE.call("smallskip")
-  end, "A fallback command for Markdown to insert a captioned table")
+  end, "A fallback command for Markdown to insert a captioned figure")
 
   -- C. Customizable hooks
 


### PR DESCRIPTION
Closes #51 

Disabling element numbering and/or addition to the ToC (for lists of figures or tables) when `.unnumbered` and resp. `.notoc` pseudo-classes are used.

For captioned figures, it works with Markdown, Randoc AST and Djot.

For captioned tables, it works with Djot only, as the latter allows attributes on any element (here the table), but regular Markdown does not have that capability.