### PR TITLE
Centered envs introduce vertical spaces in tables (workaround)

### DIFF
--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -139,7 +139,16 @@ function Renderer:table (node)
   local numberOfCols = #row.c
   local cWidth = {}
   for i = 1, numberOfCols do
-    cWidth[i] = string.format("%.5f%%lw", 100 / numberOfCols)
+    -- Currently we make all columns the same width, with the table taking
+    -- a full line width. Well, nearly full: 99.9% to avoid 100% which
+    -- causes issues in SILE flushed/centered environments, but this is
+    -- deemed acceptable (hardly visible, and in most case we have some
+    -- rounding anyway with the number format, so we aren't really making
+    -- things worse).
+    -- N.B. For future consideration: in Djot we could use a table attribute
+    -- for specifying the target width. This would however require some
+    -- changes to the ptable implementation, though...
+    cWidth[i] = string.format("%.5f%%lw", 99.9 / numberOfCols)
   end
   local ptable = utils.createStructuredCommand("ptable", {
      cols = table.concat(cWidth, " "),

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -183,7 +183,13 @@ local function SileAstWriter (options)
 
     local cWidth = {}
     for i = 1, numberOfCols do
-      cWidth[i] = string.format("%.5f%%lw", 100 / numberOfCols)
+    -- Currently we make all columns the same width, with the table taking
+    -- a full line width. Well, nearly full: 99.9% to avoid 100% which
+    -- causes issues in SILE flushed/centered environments, but this is
+    -- deemed acceptable (hardly visible, and in most case we have some
+    -- rounding anyway with the number format, so we aren't really making
+    -- things worse).
+      cWidth[i] = string.format("%.5f%%lw", 99.9 / numberOfCols)
     end
     local ptable = utils.createStructuredCommand("ptable", { header = true, cols = table.concat(cWidth, " ") }, ptableRows)
 

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -361,7 +361,13 @@ Pandoc.Table = function (_, caption, colspecs, thead, tbodies, tfoot)
 
   local cWidth = {}
   for i = 1, numberOfCols do
-    cWidth[i] = string.format("%.5f%%lw", 100 / numberOfCols)
+    -- Currently we make all columns the same width, with the table taking
+    -- a full line width. Well, nearly full: 99.9% to avoid 100% which
+    -- causes issues in SILE flushed/centered environments, but this is
+    -- deemed acceptable (hardly visible, and in most case we have some
+    -- rounding anyway with the number format, so we aren't really making
+    -- things worse).
+    cWidth[i] = string.format("%.5f%%lw", 99.9 / numberOfCols)
   end
   local ptable = utils.createStructuredCommand("ptable", {
     cols = table.concat(cWidth, " "),


### PR DESCRIPTION
Closes #53 

Rounding table width at 99.9% rather than 100%
This is an acceptable workaround:
- Hardly visible
- There's already some rounding in effect (due to the float precision .5f on each column)
- The table/cell borders are anyway a bit off (see ptable, the bottom and right borders are drawn "outside" the box to ensure proper overlapping)