### PR TITLE
fix: support Djot attributes on more inline elements

### DIFF
--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -428,35 +428,51 @@ function Renderer:superscript (node)
 end
 
 function Renderer:emph (node)
-  if node.attr then
-    SU.warn("Ignoring attributes on Djot emph") -- TODO not sure what to expect
-  end
   local content = self:render_children(node)
+  if node.attr then
+    -- Add a span for attributes
+    -- Applied first before the font change, so that font-specific attributes
+    -- are applied in the right context (e.g. .underline)
+    content = utils.createCommand("markdown:internal:span" , node.attr, content)
+  end
   return utils.createCommand("em", {}, content)
 end
 
 function Renderer:strong (node)
-  if node.attr then
-    SU.warn("Ignoring attributes on Djot strong") -- TODO not sure what to expect
-  end
   local content = self:render_children(node)
+  if node.attr then
+    -- Add a span for attributes
+    -- Applied first before the font change, so that font-specific attributes
+    -- are applied in the right context (e.g. .underline)
+    content = utils.createCommand("markdown:internal:span" , node.attr, content)
+  end
   return utils.createCommand("strong", {}, content)
 end
 
 function Renderer:double_quoted (node)
-  if node.attr then
-    SU.warn("Ignoring attributes on Djot double quoted") -- TODO not sure what to expect
-  end
   local content = self:render_children(node)
-  return utils.createCommand("doublequoted", {}, content)
+  content = utils.createCommand("doublequoted", {}, content)
+  if node.attr then
+    -- Add a span for attributes
+    -- Applied after, so as to encompass the quotes.
+    -- That's probably the expectation, so e.g. "text"{lang=fr} will use French
+    -- primary quotations marks.
+    content = utils.createCommand("markdown:internal:span" , node.attr, content)
+  end
+  return content
 end
 
 function Renderer:single_quoted (node)
-  if node.attr then
-    SU.warn("Ignoring attributes on Djot single quoted") -- TODO not sure what to expect
-  end
   local content = self:render_children(node)
-  return utils.createCommand("singlequoted", {}, content)
+  content = utils.createCommand("singlequoted", {}, content)
+  if node.attr then
+    -- Add a span for attributes
+    -- Applied after, so as to encompass the quotes.
+    -- That's probably the expectation, so e.g. 'text'{lang=fr} will use French
+    -- secondary quotations marks.
+    content = utils.createCommand("markdown:internal:span" , node.attr, content)
+  end
+  return content
 end
 
 function Renderer.left_double_quote (_)


### PR DESCRIPTION
That is: `strong`, `emph`, `double_quoted` and `single_quoted`.

Marked as a bug: we produced a warning here, but it clearly doesn't meet the expectations.

So now these are supported, for instance, instead of producing a warning:

```
*strong*{.underline} or _emphasis_{.smallcaps}
"text"{lang=fr} or 'text'{lang=fr}
```

There's a small catch maybe:
- For strong and emphasis, the attributes are applied around the content, before applying the font change (so that font-related attributes are evaluated in the expected context, e.g. underlining or striking out may use font properties)
- For quotes, the attributes are applied around the quoted content, i.e. after applying the quotes (so that language change as show here produces the right quotation marks in the target language).

