### PR TITLE
fix: change default to the 20% rule for thematic break in Djot

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -262,9 +262,9 @@ The `.dinkus` pseudo-class produces a "dinkus".
   {.dinkus}
   ***
 
-The `.rule` pseudo-class produces a centered horizontal rule, taking 20% of the line.
+The `.fullrule` pseudo-class produces full rule, taking all the line width.
 
-  {.rule}
+  {.fullrule}
   ***
 
 The `.bigrule` pseudo-class produces a centered horizontal rule, taking 33% of the line.
@@ -282,7 +282,7 @@ The `.none` pseudo-class produces nothing...
   {.none}
   ***
 
-Otherwise, everything else produces a full rule.
+Otherwise, everything else produces a centered horizontal rule, taking 20% of the line.
 
   ***
 

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -223,23 +223,23 @@ function package:registerCommands ()
       SILE.call("center", {}, { "⁂" }) -- Asterism
     elseif hasClass(options, "dinkus") then
       SILE.call("center", {}, { "* * *" }) -- Dinkus (with em-spaces)
-    elseif hasClass(options, "rule") then
-        SILE.call("center", {}, function ()
-          SILE.call("raise", { height = "0.5ex" }, function ()
-            SILE.call("hrule", { width = "20%lw" })
-        end)
-      end)
     elseif hasClass(options, "bigrule") then
       SILE.call("center", {}, function ()
         SILE.call("raise", { height = "0.5ex" }, function ()
           SILE.call("hrule", { width = "33%lw" })
         end)
       end)
+    elseif hasClass(options, "fullrule") and self:hasCouyards() then
+      SILE.call("fullrule")
     elseif hasClass(options, "pendant") and self:hasCouyards() then
       SILE.call("smallskip")
       SILE.call("couyard", { type = 6, width = "default" })
     elseif not hasClass(options, "none") then
-      SILE.call("fullrule")
+      SILE.call("center", {}, function ()
+        SILE.call("raise", { height = "0.5ex" }, function ()
+          SILE.call("hrule", { width = "20%lw" })
+        end)
+      end)
     end
 
     if hasClass(options, "pagebreak") then


### PR DESCRIPTION
for consistency with our native Markdown approach, and because we want the default behavior to be typographically sound, we even stated it!

So we introduce `.fullrule` for users who really want it, but they now have to make it explicit, and we remove our `.rule` since it becomes the default.

Nice 20% rule:
```
---
```

Ugly full rule:
```
{.fullrule}
---
```

Not considered a breaking change as the default wasn't very consistent with what we did in Markdown. And I don't care, full rules are ugly lol.
