### PR TITLE
feat: add .nobreak pseudo-class on span/inline elements

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -299,8 +299,11 @@ pseudo-class.
 
 #### Smarter typography
 
-The `.decimal` pseudo-class attribute instructs the converter to consider numbers
+On inline content, the `.decimal` pseudo-class attribute instructs the converter to consider numbers
 in the content as decimal numbers, formatted with suitable decimal mark and digit grouping according
 to the usage in the current language.
 This allows, say, 1984 to be rendered as "[1984]{ .decimal } years ago" in English,
 or "[1984 années]{ .decimal lang=fr }" in French, with appropriate separators.
+
+The `.nobreak` pseudo-class attribute on inline content ensures that line-breaking will not be applied
+there. Use it wisely around small pieces of text or you might end up with more serious justificatin issues! Yet, it might be useful for proper names, etc.

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -515,6 +515,8 @@ to the usage in the current language.
 This allows, say, 1984 to be rendered as "[1984]{ .decimal } years ago" in English,
 or "[1984 années]{ .decimal lang=fr }" in French, with appropriate separators.
 
+Another pseudo-class `.nobreak` is supported on "span" elements. It ensures the content will not be line-broken. Use it wisely around small pieces of text or you might end up with more serious justificatin issues! Yet, it might be useful for proper names, etc.
+
 When smart typography is enabled, the native converter also supports automatically converting
 straight single and double quotes after digits to single and double primes.
 It can be useful for easily typesetting units (e.g. 6")

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -399,8 +399,10 @@ Please consider using a resilient-compatible class!]])
       cascade:call("underline")
     end
     if options["custom-style"] then
-      -- The style (or the hook) is reponsible for paragraphing
       cascade:call("markdown:custom-style:hook", { name = options["custom-style"], scope = "inline" })
+    end
+    if hasClass(options, "nobreak") then
+      cascade:call("hbox")
     end
     cascade:process(content)
   end, "Span in Markdown (internal)")


### PR DESCRIPTION
Because most of the time it's quite bad to have a line-break hyphenation in the middle of a proper name... and it might be more acceptable to have a poorly justified line (e.g. stretched, with proper emergency stretch settings) than to allow the hyphenation there...