### PR TITLE
fix: honor more attributes on direct links

### DIFF
--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -375,9 +375,13 @@ with headers, the `.unnumbered` class specifier is also supported.], `start` and
 
 ### Basic links
 
-Here is a link to [the SILE website](https://sile-typesetter.org/).
+Here is a link to the [SILE website](https://sile-typesetter.org/).
 It might not be visible in the PDF output, but hover it and click. It just works.
 Likewise, here is an internal link to the "[Basic typesetting](#basic-typesetting)" section.
+
+You can use attributes on links:
+the [SILE website](https://sile-typesetter.org/){.underline}.^[Within a **resilient** class,
+we'd possibly recommend using a custom style to color links, etc.]
 
 ### Cross-references
 

--- a/packages/markdown/utils.lua
+++ b/packages/markdown/utils.lua
@@ -50,6 +50,30 @@ local function createStructuredCommand (command, options, contents)
   return result
 end
 
+--- Extract the content tree of a command, assuming we already took care of it.
+-- This is SU.subContent() done right, without the id=stuff and other weirdness...
+--
+-- @tparam table  contents content tree list
+local function subTreeContent (content)
+  local out = {}
+  for _, val in ipairs(content) do
+    out[#out+1] = val
+  end
+  return out
+end
+
+--- Remove a command from the AST and return it for separate processing.
+--
+-- @tparam  table  contents content tree list
+-- @tparam  string command name of the command
+local function extractFromTree (tree, command)
+  for i = 1, #tree do
+    if type(tree[i]) == "table" and tree[i].command == command then
+      return table.remove(tree, i)
+    end
+  end
+end
+
 --- Some other utility functions.
 -- @section utils
 
@@ -101,5 +125,7 @@ return {
   normalizeLang = normalizeLang,
   createCommand = createCommand,
   createStructuredCommand = createStructuredCommand,
+  subTreeContent = subTreeContent,
+  extractFromTree = extractFromTree,
   nbspFilter = nbspFilter,
 }


### PR DESCRIPTION
We only processed the id and the src, but other attributes are interesting to propagate as in a span (styles, etc.)

Closes #67 