### PR TITLE
feat: render fenced code blocks marked as markdown or djot

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -232,6 +232,22 @@ graph {
 }
 ```
 
+Code blocks marked as being in Markdown or Djot are interpretated too (again, unless
+the `render` attribute is set to false).
+For Markdown, attributes are passed to the renderer, allowing to possibly use different compatibility options (see "[Configuration](#configuration)").
+This feature allows switching between those languages, would there be something one does not support yet.
+At the time of writing, for instance, Djot does not support "line blocks".
+
+This very chapter being written in Djot, let's just switch to Markdown and type some poetry.
+
+```markdown
+::: {.poetry}
+| I took up the runes,
+|  screaming I took them,
+| then I fell back from there.
+:::
+```
+
 #### Raw blocks
 
 ```=sile
@@ -306,4 +322,4 @@ This allows, say, 1984 to be rendered as "[1984]{ .decimal } years ago" in Engli
 or "[1984 années]{ .decimal lang=fr }" in French, with appropriate separators.
 
 The `.nobreak` pseudo-class attribute on inline content ensures that line-breaking will not be applied
-there. Use it wisely around small pieces of text or you might end up with more serious justificatin issues! Yet, it might be useful for proper names, etc.
+there. Use it wisely around small pieces of text or you might end up with more serious justification issues! Yet, it might be useful for proper names, etc.

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -450,6 +450,11 @@ graph {
 }
 ```
 
+Code blocks marked as being in Markdown or Djot are interpretated too (again, unless
+the `render` attribute is set to false).
+This feature allows switching between those languages, would there be something one does not support yet.
+For Markdown, attributes are passed to the renderer, allowing to possibly use different compatibility options (see "[Configuration](#configuration)").
+
 ### Raw blocks
 
 Last but not least, the converter supports a `{=sile}` annotation on code blocks, to pass
@@ -519,7 +524,7 @@ to the usage in the current language.
 This allows, say, 1984 to be rendered as "[1984]{ .decimal } years ago" in English,
 or "[1984 années]{ .decimal lang=fr }" in French, with appropriate separators.
 
-Another pseudo-class `.nobreak` is supported on "span" elements. It ensures the content will not be line-broken. Use it wisely around small pieces of text or you might end up with more serious justificatin issues! Yet, it might be useful for proper names, etc.
+Another pseudo-class `.nobreak` is supported on "span" elements. It ensures the content will not be line-broken. Use it wisely around small pieces of text or you might end up with more serious justification issues! Yet, it might be useful for proper names, etc.
 
 When smart typography is enabled, the native converter also supports automatically converting
 straight single and double quotes after digits to single and double primes.

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -563,7 +563,8 @@ Please consider using a resilient-compatible class!]])
   end, "Captioned figure in Markdown (internal)")
 
   self:registerCommand("markdown:internal:codeblock", function (options, content)
-    if hasClass(options, "dot") and SU.boolean(options.render, true) then
+    local render = SU.boolean(options.render, true)
+    if render and hasClass(options, "dot") then
       local handler = SILE.rawHandlers["embed"]
       if not handler then
         -- Shouldn't occur since we loaded the embedders package
@@ -571,6 +572,10 @@ Please consider using a resilient-compatible class!]])
       end
       options.format = options.class
       handler(options, content)
+    elseif render and hasClass(options, "djot") then
+      SILE.processString(SU.contentToString(content), "djot", nil, options)
+    elseif render and hasClass(options, "markdown") then
+      SILE.processString(SU.contentToString(content), "markdown", nil, options)
     elseif hasClass(options, "lua") then
       -- Naive syntax highlighting for Lua, until we have a more general solution
       SILE.call("verbatim", {}, function ()


### PR DESCRIPTION
Or "how can I get nice poetry in my book typeset in Djot while the latter has no line blocks yet"