### PR TITLE
Support highlighting (==mark==) in Markdown

### DIFF
--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -79,6 +79,7 @@ obtained with `H~2~O` and `2^10^` respectively.
 Other nice features include:
 
  - ~~deletions~~ with `~~deletions~~`
+ -  ==highlight== with `==highlight==`
  - [underlines]{.underline} with `[underlines]{.underline}`
  -  and even [Small Caps]{.smallcaps}, as `[Small Caps]{.smallcaps}`
 
@@ -538,7 +539,7 @@ the `\autodoc:command{\include}`{=sile} command or the `\autodoc:environment[che
 environment to tune the behavior of the Markdown parser.
 
 ::: {custom-style=raggedright}
-> Available options are: `smart`, `smart_primes`, `strikeout`, `subscript`, `superscript`,
+> Available options are: `smart`, `smart_primes`, `strikeout`, `mark`, `subscript`, `superscript`,
 > `definition_lists`, `notes`, `inline_notes`,
 > `fenced_code_blocks`, `fenced_code_attributes`, `bracketed_spans`, `fenced_divs`,
 > `raw_attribute`, `link_attributes`,

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -367,14 +367,10 @@ function Renderer:span (node)
 end
 
 function Renderer:mark (node)
-  SU.warn("Djot mark (highlight) is not fully implemented") -- See HACK
+  local options = node.attr or {}
   local content = self:render_children(node)
-  local out = utils.createCommand("color", { color = "red" }, content) -- HACK
-  if node.attr then
-    -- Add a div when containing attributes
-    return utils.createCommand("markdown:internal:span", node.attr, out)
-  end
-  return out
+  djotast.insert_attribute(options, "class", "mark")
+  return utils.createCommand("markdown:internal:span", options, content)
 end
 
 function Renderer:insert (node)

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -392,6 +392,7 @@ function inputter:parse (doc)
     fenced_divs = true,
     raw_attribute = true,
     link_attributes = true,
+    mark = true,
     startnum = true,
     fancy_lists = true,
     task_list = true,

--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -103,6 +103,7 @@ parsers.citation_chars         = parsers.alphanumeric
 parsers.internal_punctuation   = S(":;,.?")
 
 parsers.doubleasterisks        = P("**")
+parsers.doubleequals           = P("==")
 parsers.doubleunderscores      = P("__")
 parsers.doubletildes           = P("~~")
 parsers.fourspaces             = P("    ")
@@ -750,6 +751,10 @@ end
 --     :   Enable strike-through support for a text enclosed within double
 --         tildes, as in `~~deleted~~`.
 --
+--     `mark`
+--     :   Enable highlighting support for a text enclosed within double
+--         equals, as in `==marked==`.
+--
 --     `superscript`
 --     :   Enable superscript support. Superscripts may be written by surrounding
 --         the superscripted text by `^` characters, as in `2^10^.
@@ -926,6 +931,9 @@ function M.new(writer, options)
   end
   if options.tex_math_dollars then
     specials = specials .. "$"
+  end
+  if options.mark then
+    specials = specials .. "="
   end
   larsers.specialchar         = S(specials)
 
@@ -1209,6 +1217,13 @@ function M.new(writer, options)
                  = ( parsers.between(parsers.Inline, parsers.doubletildes,
                                    parsers.doubletildes)
                    ) / writer.strikeout
+
+  larsers.Mark
+                 = ( parsers.between(parsers.Inline, parsers.doubleequals,
+                                   parsers.doubleequals)
+                   ) / function (inlines, x, y)
+                        return writer.span(inlines, { class="mark" })
+                       end
 
   larsers.Span   = ( parsers.between(parsers.Inline, parsers.lbracket,
                                    parsers.rbracket) ) * ( parsers.attributes )
@@ -1838,6 +1853,7 @@ function M.new(writer, options)
                             + V("Emph")
                             + V("Span")
                             + V("Strikeout")
+                            + V("Mark")
                             + V("Subscript")
                             + V("Superscript")
                             + V("InlineNote")
@@ -1864,6 +1880,7 @@ function M.new(writer, options)
       Emph                  = larsers.Emph,
       Span                  = larsers.Span,
       Strikeout             = larsers.Strikeout,
+      Mark                  = larsers.Mark,
       Subscript             = larsers.Subscript,
       Superscript           = larsers.Superscript,
       InlineNote            = larsers.InlineNote,
@@ -1917,6 +1934,10 @@ function M.new(writer, options)
 
   if not options.strikeout then
     syntax.Strikeout = parsers.fail
+  end
+
+  if not options.mark then
+    syntax.Mark = parsers.fail
   end
 
   if not options.raw_attribute then

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -401,6 +401,9 @@ Please consider using a resilient-compatible class!]])
     if hasClass(options, "smallcaps") then
       cascade:call("font", { features = "+smcp" })
     end
+    if hasClass(options, "mark") then
+      cascade:call("color", { color = "red" }) -- FIXME TODO We'd need real support
+    end
     if hasClass(options, "strike") then
       cascade:call("strikethrough")
     end


### PR DESCRIPTION
- Added `==mark==` support to the native Markdown (vendored lunamark + markdown package)
- Refactor slightly the native djot package to use common logic
- Nothing done for the pandocast package, but if I correctly read the incoming change, Pandoc expands it as a Span so we get it for free.