### PR TITLE
fix: lunamark regression on smart ellipses since math support was introduced

### DIFF
--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -927,7 +927,7 @@ function M.new(writer, options)
 
   local specials = "*_~`&[]<!\\-@^"
   if options.smart then
-    specials = specials .. "'\""
+    specials = specials .. "'.\""
   end
   if options.tex_math_dollars then
     specials = specials .. "$"


### PR DESCRIPTION
Introduced in 0139e114b9cbc6df017e2a64a9487d43a57d76f4 = that small dot was overlooked

![image](https://github.com/Omikhleia/markdown.sile/assets/18075640/6ace40c3-bedb-49ab-ba1b-8e78ddd30be8)
