### PR TITLE
fix: lunamark Pandoc-like attributes are too restrictive

### DIFF
--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -152,10 +152,12 @@ parsers.indented_blocks = function(bl)
 end
 
 -- Attributes list as in Pandoc {#id .class .class-other key=value key2="value 2"}
--- N.B. For attribute values, Pandoc may possibly accept more things than us here,
--- the details may have to be checked.
-parsers.identifier  = parsers.letter
-                      * (parsers.alphanumeric + S("_-"))^0
+--   Note: Pandoc has the same identifier definitions, but its interpretation
+--   of a letter (and by extension an alphanumeric value) extends to alphabetic
+--   *Unicode* characters.
+parsers.attrid      = parsers.letter
+                      * (parsers.alphanumeric + S("_-:."))^0
+
 parsers.attrvalue   = (parsers.dquote
                       * C((parsers.anyescaped - parsers.dquote)^0)
                       * parsers.dquote)
@@ -164,16 +166,16 @@ parsers.attrvalue   = (parsers.dquote
                       * parsers.squote)
                     + C((parsers.anyescaped - parsers.dquote - parsers.space - P("}"))^1)
 
-parsers.attrpair    = Cg(C((parsers.identifier)^1)
+parsers.attrpair    = Cg(C((parsers.attrid)^1)
                       * parsers.optionalspace * parsers.equal * parsers.optionalspace
                       * parsers.attrvalue)
                       * parsers.optionalspace^-1
 parsers.attrlist    = Cf(Ct("") * parsers.attrpair^0, rawset)
 
-parsers.class       = (P("-") * Cc("unnumbered")) + (parsers.period * C((parsers.identifier)^1))
+parsers.class       = (P("-") * Cc("unnumbered")) + (parsers.period * C((parsers.attrid)^1))
 parsers.classes     = (parsers.class * parsers.optionalspace)^0
 
-parsers.hashid      = parsers.hash * C((parsers.identifier)^1)
+parsers.hashid      = parsers.hash * C((parsers.alphanumeric + S("-_:."))^1)
 
 parsers.attributes  = P("{") * parsers.optionalspace
                       * Cg(parsers.hashid^-1) * parsers.optionalspace
@@ -185,7 +187,8 @@ parsers.attributes  = P("{") * parsers.optionalspace
                           return attr
                         end
 -- Raw attributes similar to Pandoc (=format key=value key2="value 2")
-parsers.raw              = parsers.equal * C((parsers.identifier)^1) * parsers.optionalspace
+parsers.rawid            = parsers.alphanumeric + S("_-")
+parsers.raw              = parsers.equal * C((parsers.rawid)^1) * parsers.optionalspace
 parsers.rawattributes    = P("{") * parsers.optionalspace
                           * parsers.raw * Cg(parsers.attrlist)
                           * parsers.optionalspace * P("}")


### PR DESCRIPTION
Backported from my own PR to lunamark: https://github.com/jgm/lunamark/pull/68