### PR TITLE
Djot epigraph extension feature

### DIFF
--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -329,7 +329,6 @@ there. Use it wisely around small pieces of text or you might end up with more s
 [^:pumpernickel:]: Herbert _"Froggie"_ Pumpernickel{.smallcaps .nobreak}
 [^:disclaimer:]: _Big disclaimer:_ This interpretation of symbols is not standard.
   We might have to reconsider it as Djot evolves.
-  It is still a specification in progress!
 
 Let's now pretend that you are writing an essay about some fictitious :pumpernickel:.
 
@@ -364,3 +363,27 @@ Of course, these pseudo-footnotes[^djot-pseudo-footnotes] can in turn contain sy
 
 [^djot-pseudo-footnotes]: You may still use them as regular footnotes.
 Whether this is a good idea is another question...
+
+### Attributed quotes (epigraphs)
+
+{ rule="0.4pt" }
+> The Library is a sphere whose exact centre is any one of its
+> hexagons and whose circumference is inaccessible.
+^ Jorge Luis [Borges]{.smallcaps}, "The Library of Babel"
+
+Standard Djot only honors captions on tables, and ignores them on other block elements.
+When using a **resilient** document class, however, a captioned block quote is rendered as an "epigraph", with the caption content used as its "source" (in a broad sense).
+For instance, the above quote was obtained with:
+
+```
+{ rule="0.4pt" }
+> The Library is a sphere whose exact centre is any one of its
+> hexagons and whose circumference is inaccessible.
+^ Jorge Luis [Borges]{.smallcaps}, "The Library of Babel"
+```
+
+Attributes are passed through to an implicit "div" (so as to honor the language, a link target identifier, etc.) and eventually to the underlying epigraph environment.
+Any option supported by the `\autodoc:package{resilient.epigraph}`{=sile} package may thus be used.
+
+Be aware that this behavior is currently an extension.
+Other Djot renderers will therefore likely skip the caption.

--- a/examples/sile-and-markdown-manual-styles.yml
+++ b/examples/sile-and-markdown-manual-styles.yml
@@ -21,6 +21,46 @@ blockquote:
       before:
         skip: "smallskip"
 
+epigraph:
+  origin: "resilient.epigraph"
+  style:
+    font:
+      size: "0.9em"
+    paragraph:
+      after:
+        skip: "bigskip"
+      before:
+        skip: "medskip"
+
+epigraph-source:
+  origin: "resilient.epigraph"
+  style:
+    paragraph:
+      align: "right"
+      before:
+        indent: false
+        vbreak: false
+
+epigraph-source-norule:
+  inherit: "epigraph-source"
+  origin: "resilient.epigraph"
+  style:
+    paragraph:
+      before:
+        skip: "smallskip"
+
+epigraph-source-rule:
+  inherit: "epigraph-source"
+  origin: "resilient.epigraph"
+  style:
+
+epigraph-text:
+  inherit: "epigraph"
+  origin: "resilient.epigraph"
+  style:
+    paragraph:
+      align: "justify"
+
 fancytoc-base:
   style:
 
@@ -443,9 +483,9 @@ sectioning-chapter-main-number:
   inherit: "sectioning-chapter-base-number"
   origin: "resilient.book"
   style:
+    color: "#66a0b3"
     font:
       size: "3em"
-    color: "#66a0b3"
     numbering:
       after:
         kern: "3spc"

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -82,7 +82,16 @@ end
 
 function Renderer:blockquote (node)
   local content = self:render_children(node)
-  local out = utils.createCommand("markdown:internal:blockquote", {}, content)
+  local out
+  if node.caption then
+    local caption = self:render_children(node.caption)
+    out = utils.createStructuredCommand("markdown:internal:captioned-blockquote", node.attr or {}, {
+      content,
+      utils.createCommand("caption", {}, caption)
+    })
+  else
+    out = utils.createCommand("markdown:internal:blockquote", {}, content)
+  end
   if node.attr then
     -- Add a div when containing attributes
     return utils.createCommand("markdown:internal:div", node.attr, out)
@@ -185,8 +194,8 @@ function Renderer:cell (node)
 end
 
 function Renderer.caption (_, _)
-  -- Extracted at table processing, so we should not enter this method.
-  SU.error("Should not be invoked")
+  -- Extracted at processing, so we should not enter this method.
+  SU.error("Caption rendering is not expected here.")
 end
 
 local listStyle = {
@@ -575,7 +584,7 @@ end
 
 function inputter.parse (_, doc)
   local djot = require("djot")
-  local ast = djot.parse(doc)
+  local ast = djot.parse(doc, false, function (warning) SU.warn(warning.message) end)
   local renderer = Renderer()
   local tree = renderer:render(ast)
 

--- a/lua-libraries/djot/ast.lua
+++ b/lua-libraries/djot/ast.lua
@@ -828,10 +828,23 @@ local function to_ast(parser, sourcepos)
           if prevnode and prevnode.t == "table" then
             -- move caption in table node
             table.insert(prevnode.c, 1, node)
+          -- BEGIN EXTENSION DIDIER 20230523
+          -- Accept caption on other elements (Djot non-standard extension)
+          elseif prevnode then
+            if prevnode.caption then
+              warn({ message = "Ignoring multiple caption",
+                     pos = startpos })
+            end
+            prevnode.caption = { c = node.c }
           else
-            warn({ message = "Ignoring caption without preceding table",
+            warn({ message = "Ignoring caption without preceding content",
                    pos = startpos })
           end
+          -- else
+          --   warn({ message = "Ignoring caption without preceding table",
+          --          pos = startpos })
+          -- end
+          -- END DIDIER
           return
 
         elseif tag == "heading" then

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -331,6 +331,7 @@ Please consider using a resilient-compatible class!]])
   self:registerCommand("markdown:internal:term", function (_, content)
     SILE.typesetter:leaveHmode()
     SILE.call("font", { weight = 600 }, content)
+    SILE.call("novbreak")
   end, "Definition list term in Markdown (internal)")
 
   self:registerCommand("markdown:internal:definition", function (_, content)

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -170,6 +170,11 @@ function package:_init (_)
 
   -- Optional packages
   pcall(function () return self.class:loadPackage("couyards") end)
+
+  -- Other conditional packages
+  if self.isResilient then
+    self.class:loadPackage("resilient.epigraph")
+  end
 end
 
 function package:hasCouyards ()
@@ -656,6 +661,27 @@ Please consider using a resilient-compatible class!]])
       SILE.call("kern", { width = widthsp })
     end
   end, "Inserts a non-breakable inter-word space (internal)")
+
+  self:registerCommand("markdown:internal:captioned-blockquote", function (options, content)
+    if type(content) ~= "table" then
+      SU.error("Expected a table AST content in captioned blockquote environment")
+    end
+    local title = utils.extractFromTree(content, "caption")
+
+    if SILE.Commands["epigraph"] then -- asssuming the implementation from resilient.epigraph.
+      if title then
+        -- Trick: Put the extract title back as "\source"
+        title.command = "source"
+        content[#content+1] = title
+      end
+      SILE.call("epigraph", options, content)
+    else
+      SU.warn([[Apparently, you are not using a resilient class.
+Quotation captions are ignored.
+Please consider using a resilient-compatible class!]])
+      SILE.call("markdown:internal:blockquote", options, content)
+    end
+  end, "Captioned blockquote in Djot (internal)")
 
   -- B. Fallback commands
 


### PR DESCRIPTION
Exprimental attributed quotes or epigraphs:

Extending the Djot reader to process a caption on a blockquote:

```
> Some quote...
> Lorem ipsum...
^ Quote source as a caption
```

See discussion https://github.com/jgm/djot/issues/28#issuecomment-1535554065 for the possibility of generalizing captions...

Only applied to blockquotes only in this PR, as I need a "quick" solution for epigraphs -- there would be other ways to do it eventually, so let's aim at something simple to start with.