### PR TITLE
Header shifting option for Markdown, Djot, Pandoc AST

### DIFF
--- a/classes/markdown.lua
+++ b/classes/markdown.lua
@@ -1,10 +1,21 @@
+--- "Stupid" class so that processing Markdown, Djot and Pandoc AST is directly
+-- available from command line, without having to write a SILE document.
+-- It also aims at overriding the legacy markdown class from SILE, as long as
+-- it is shipped with the core distribution.
+--
 local book = require("classes.book")
 local class = pl.class(book)
 class._name = "markdown"
 
 function class:_init (options)
   book._init(self, options)
+  -- Load all the packages: corresponding inputters are then also registered.
+  -- Since we support switching between formats via "code blocks", we want
+  -- to make it easier for the user and not have him bother about how to load
+  -- the right inputter and appropriate packages.
+  self:loadPackage("djot")
   self:loadPackage("markdown")
+  self:loadPackage("pandocast")
   return self
 end
 

--- a/examples/introduction.md
+++ b/examples/introduction.md
@@ -4,9 +4,9 @@ This collection of modules for the [SILE](https://github.com/sile-typesetter/sil
 system provides a complete redesign of its former native Markdown support, with
 a great set of Pandoc-like extensions and plenty of extra goodies.
 
-- `\autodoc:package{markdown}`{=sile} inputter and package: native support of Markdown files.
-- `\autodoc:package{pandocast}`{=sile} inputter and package: native support of Pandoc JSON AST files.
-- `\autodoc:package{djot}`{=sile} inputter and package: native support of Djot files.
+- `\autodoc:package{markdown}`{=sile} input handler and package: native support of Markdown.
+- `\autodoc:package{djot}`{=sile} input handler and package: native support of Djot.
+- `\autodoc:package{pandocast}`{=sile} input handler and package: native support of Pandoc JSON AST files.
 
 For casual readers, this collection notably aims at easily converting Markdown or Djot documents to print-quality PDFs.
 
@@ -38,20 +38,25 @@ sile -u inputters.markdown somefile.md
 ... Or for a Djot document.
 
 ```
-sile -u inputters.djot -u packages.markdown somefile.dj
+sile -u inputters.djot somefile.dj
 ```
 
-This method directly produces a PDF from the input file, using SILE's standard **book** class.
+This method directly produces a PDF from the input file, using SILE's standard **book** class.[^intro-book-class]
+
+[^intro-book-class]: Actually, it uses a **markdown** class derived from the standard book class and loading the required modules.
+You don't really have to know that, unless you intend to invoke SILE with the `-c` option to specify another class of your choice; in that case you will need to load additional modules explicitly---unless it is a resilient class, of course.
 
 ### Usage with the resilient collection
 
-To unleash the full potential of this package collection, we recommend that
-you also install our [**resilient.sile**](https://github.com/Omikhleia/resilient.sile)
-collection of classes and packages.
+To unleash the full potential of this package collection, we recommend that you also install our [**resilient.sile**](https://github.com/Omikhleia/resilient.sile) collection of classes and packages.
+
+```bash
+luarocks --lua-version 5.4 install --dev resilient.sile
+```
 
 Then, you can automatically benefit from a few advanced features.
-Conversion from command line just requires to load a resilient class, and optionally
-the poetry package. For instance:
+Conversion from command line just requires to load a resilient class, and optionally the poetry package.
+For instance:
 
 ```
 sile -c resilient.book -u inputters.markdown -u packages.resilient.poetry somefile.md
@@ -59,8 +64,17 @@ sile -c resilient.book -u inputters.markdown -u packages.resilient.poetry somefi
 
 (And likewise for the Pandoc AST or Djot processing.)
 
-A "resilient style file" is also generated. It can be modified to change many styling
-decisions and adapt the output at convenience.
+A "resilient style file" is also generated.
+It can be modified to change many styling decisions and adapt the output at convenience.
+
+### Advanced usage from existing documents
+
+While direct conversion from the command line may be adequate for very simple workflows, there are a number of things usually best addressed by using some kind of "wrapper" document.
+
+This package collection provides several ways for including Markdown or Djot content in documents written in SIL syntax, the default mark-up language provided by SILE.
+These are described further in this guide.
+
+The resilient collection also introduces a "master document" format, streamlining several usual tasks. Give it a chance, and you may even end up producing a book with SILE without a single statement in SIL.
 
 ### Credits
 

--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -387,3 +387,20 @@ Any option supported by the `\autodoc:package{resilient.epigraph}`{=sile} packag
 
 Be aware that this behavior is currently an extension.
 Other Djot renderers will therefore likely skip the caption.
+
+### Configuration
+
+You can pass additional options to the `\autodoc:command{\include}`{=sile} command or the `\autodoc:environment[check=false]{raw}`{=sile} environment to tune the behavior of the renderer.
+
+The `shift_headings` option can take an integer value and causes headers in included or embedded raw content to be offset (that is, shifted by the given amount).
+For instance:
+
+```
+\include[src=somefile.dj, shift_headings=1]
+```
+
+For document classes supporting it, this feature also allows you to access levels above the default scheme, such as "parts".
+
+```
+\include[src=somefile.dj, shift_headings=-1]
+```

--- a/examples/sile-and-markdown-manual.sil
+++ b/examples/sile-and-markdown-manual.sil
@@ -62,7 +62,7 @@ Creative Commons Attribution, Share-Alike License,
 version 2.0 (http://creativecommons.org/licenses/by-sa/2.0/).
 
 \pagebreak
-\fancytableofcontents[start=2]
+\tableofcontents
 %
 % Introduction chapter
 %
@@ -148,4 +148,7 @@ our package might not support them well. Its main focus is on Markdown parity wi
 \include[src=pandoc-tables.pandoc]
 
 \include[src=sile-and-djot.dj]
+
+\include[src=sile-and-pandoc.dj]
+
 \end{document}

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -534,9 +534,9 @@ or coordinates (e.g. Oxford is located at 51° 45' 7" N, 1° 15' 27" W).
 
 ### Configuration {#configuration}
 
-Most Markdown syntax extensions are enabled by default. You can pass additional options to
-the `\autodoc:command{\include}`{=sile} command or the `\autodoc:environment[check=false]{raw}`{=sile}
-environment to tune the behavior of the Markdown parser.
+Most Markdown syntax extensions are enabled by default.
+You can pass additional options to
+the `\autodoc:command{\include}`{=sile} command or the `\autodoc:environment[check=false]{raw}`{=sile} environment to tune the behavior of the Markdown parser.
 
 ::: {custom-style=raggedright}
 > Available options are: `smart`, `smart_primes`, `strikeout`, `mark`, `subscript`, `superscript`,
@@ -550,62 +550,18 @@ environment to tune the behavior of the Markdown parser.
 For instance, to disable the smart typography feature:
 
 ```
-\include[src=somefile.pandoc, smart=false]
+\include[src=somefile.md, smart=false]
 ```
 
-## The Pandoc-based converters
-
-Pandoc is a free-software document converter, created by the same John MacFarlane who
-provided the **lunamark** library which empowers SILE’s native markdown package.
-The latter, though, does not offer as many options and extensions as Pandoc does,
-for advanced typesetting.
-
-In the event where the native solution would fall short for you ---e.g. would you need some extension
-it doesn't yet support--- you may want to use Pandoc directly for converting your document to an
-output suitable for SILE.
-
-The following solutions are still experimental proof-of-concepts, but you may give them a chance,
-and help us fill the gaps.
-
-### Using Pandoc's AST with the pandocast package
-
-The experimental `\autodoc:package{pandocast}`{=sile} package allows you to use Pandoc’s JSON AST
-as an input format for documents.
-You can obtain an AST output from Pandoc for any supported source format. Keeping the focus on
-Markdown here:
+The `shift_headings` option can take an integer value and causes headers in included or embedded raw content to be offset (that is, shifted by the given amount).
+For instance:
 
 ```
-pandoc -t json somefile.md -f markdown -o somefile.pandoc
+\include[src=somefile.md, shift_headings=1]
 ```
 
-Once the package is loaded, the `\autodoc:command{\include[src=<file>]}`{=sile} command supports
-reading and processing such a Pandoc AST file, assuming the `.pandoc` extension or specifying
-the `format=pandocast` parameter:
+For document classes supporting it, this feature also allows you to access levels above the default scheme, such as "parts".
 
 ```
-\use[module=packages.pandocast]
-\include[src=somefile.pandoc]
+\include[src=somefile.md, shift_headings=-1]
 ```
-
-This package supports the same advanced features as the native markdown package, e.g. the
-ability to use custom styles, to pass native content through to SILE, etc.
-
-There is a small _caveat_, though: one must use a version of Pandoc which generates
-an AST compatible with our parser ("inputter"). While the Pandoc AST is somewhat stable,
-it may change when new features are introduced in the software.
-
-### Using a Pandoc "custom writer" in Lua
-
-Pandoc also supports "custom writers" developed in Lua^[<https://pandoc.org/custom-writers.html>].
-
-This custom writer API is fairly recent and might change. Actually, besides a "Classic style" API
-(pending deprecation), there's now also a "New style" API...  While such custom writers may have
-some rough edges, the idea is quite appealing nevertheless. After all, SILE is mostly written in Lua,
-so the skills are there in the community.
-
-Again, there is no official solution using this conversion path, but some pretty neat
-experimental results have been
-achieved^[<https://github.com/Omikhleia/omikhleia-sile-packages/blob/main/examples/markdown-sample.pdf>].
-That custom writer targets a specific (non-standard) class and a bunch of specific packages, which might
-not have been ported to the latest version of SILE... This said, you can also certainly help pushing the
-idea forward!

--- a/examples/sile-and-pandoc.dj
+++ b/examples/sile-and-pandoc.dj
@@ -1,0 +1,49 @@
+# Alternative route: SILE and Pandoc
+
+Pandoc is a free-software document converter, created by the same John MacFarlane who provided the *lunamark* and *djot* libraries which empower SILE’s native Markdown and Djot package.
+The latter, though, do not offer as many options and extensions as Pandoc does, for advanced typesetting.
+
+In the event where the native solution would fall short for you ---e.g. would you need some extension of feature it doesn't yet support--- you may want to use Pandoc directly for converting your document to an output suitable for SILE.
+
+The following solutions are still experimental proof-of-concepts, but you may give them a chance,and help us fill the gaps.
+
+## Using Pandoc's AST with the pandocast package
+
+The experimental `\autodoc:package{pandocast}`{=sile} package allows you to use Pandoc’s JSON AST as an input format for documents.
+You can obtain an AST output from Pandoc for any supported source format. Keeping the focus on Markdown here:
+
+```
+pandoc -t json somefile.md -f markdown -o somefile.pandoc
+```
+
+Once the package is loaded, the `\autodoc:command{\include[src=<file>]}`{=sile} command supports reading and processing such a Pandoc AST file, assuming the `.pandoc` extension or specifying the `format=pandocast` parameter:
+
+```
+\use[module=packages.pandocast]
+\include[src=somefile.pandoc]
+```
+
+This package supports the same advanced features as the native Markdown solution, e.g. the ability to use custom styles, to pass native content through to SILE, etc.
+
+The `shift_headings` option is also available, as with the Markdown and Djot solutions.
+
+There is a small _caveat_, though: one must use a version of Pandoc which generates an AST compatible with our input handler ("inputter").
+While the Pandoc AST is somewhat stable, it may change when new features are introduced in the software.
+
+## Using a Pandoc "custom writer" in Lua
+
+Pandoc also supports "custom writers" developed in Lua[^pandoc-writer].
+
+[^pandoc-writer]: <https://pandoc.org/custom-writers.html>
+
+This custom writer API is fairly recent and might change.
+Actually, besides a "Classic style" API (deprecated), there's now also a "New style" API...
+While such custom writers may have some rough edges, the idea is quite appealing nevertheless. 
+After all, SILE is mostly written in Lua, so the skills are there in the community.
+
+Again, there is no official solution using this conversion path, but some pretty neat experimental results have been achieved[^omi-writer].
+That custom writer targets a specific (non-standard) class and a bunch of specific packages, which might not have been ported to the latest version of SILE...
+This said, you can also certainly help pushing the idea forward!
+
+[^omi-writer]: <https://github.com/Omikhleia/omikhleia-sile-packages/blob/main/examples/markdown-sample.pdf>
+

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -14,11 +14,12 @@ local djotast = require("djot.ast")
 
 local Renderer = pl.class()
 
-function Renderer:_init()
+function Renderer:_init(options)
   self.references = {}
   self.footnotes = {}
   self.metadata = {}
-  self.tight = false -- We do use it currently, though!
+  self.shift_headings = SU.cast("integer", options.shift_headings or 0)
+  self.tight = false -- We do not use it currently, though!
 end
 
 function Renderer:render(doc)
@@ -125,7 +126,7 @@ function Renderer:heading (node)
   -- At document level, the id is set on the section.
   -- But in nested blocks (e.g. in divs), the id is set on the header.
   options.id = options.id or self.sectionid
-  options.level = node.level
+  options.level = node.level + self.shift_headings
   return utils.createCommand("markdown:internal:header", options, content)
 end
 
@@ -592,10 +593,10 @@ function inputter.appropriate (round, filename, _)
   return false
 end
 
-function inputter.parse (_, doc)
+function inputter:parse (doc)
   local djot = require("djot")
   local ast = djot.parse(doc, false, function (warning) SU.warn(warning.message) end)
-  local renderer = Renderer()
+  local renderer = Renderer(self.options)
   local tree = renderer:render(ast)
 
   -- The "writer" returns a SILE AST.

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -65,9 +65,10 @@ end
 -- Lunamark writer for SILE
 -- Yay, direct lunamark AST ("ropes") conversion to SILE AST
 
-local function SileAstWriter (options)
+local function SileAstWriter (writerOps, renderOps)
   local generic = require("lunamark.writer.generic")
-  local writer = generic.new(options or {})
+  local writer = generic.new(writerOps or {})
+  local shift_headings = SU.cast("integer", renderOps.shift_headings or 0)
 
   -- Simple one-to-one mappings between lunamark AST and SILE
 
@@ -90,7 +91,7 @@ local function SileAstWriter (options)
 
   writer.header = function (s, level, attr)
     local opts = attr or {} -- passthru (class and key-value pairs)
-    opts.level = level
+    opts.level = level + shift_headings
     return utils.createCommand("markdown:internal:header", opts, s)
   end
 
@@ -418,7 +419,7 @@ function inputter:parse (doc)
   local writer = SileAstWriter({
     layout = "minimize" -- The default layout is to output \n\n as inter-block separator
                         -- Let's cancel it completely, and insert our own \par where needed.
-  })
+  }, self.options)
 
   extensions.alter_syntax = customSyntax(writer, extensions)
 

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -16,8 +16,6 @@ local Pandoc = {
    API_VERSION = { 1, 22, 0 } -- Supported API version (semver)
 }
 
-local utils = require("packages.markdown.utils")
-
 local function checkAstSemver(version)
   -- We shouldn't care the patch level.
   -- The Pandoc AST may change upon "minor" updates, though.
@@ -39,6 +37,14 @@ local function checkAstSemver(version)
     .. ", is more recent than supported " ..  table.concat(Pandoc.API_VERSION, ".")
     .. ", there could be issues.")
   end
+end
+
+local utils = require("packages.markdown.utils")
+
+local Renderer = pl.class()
+
+function Renderer:_init(options)
+  self.shiftheaders = SU.cast("integer", options.shiftheaders or 0)
 end
 
 -- Allows unpacking tables on some Pandoc AST nodes so as to map them to methods
@@ -74,7 +80,7 @@ local function addNodes(out, elements)
   end
 end
 
-local function pandocAstParse(element)
+function Renderer:render(element)
   local out
   if type(element) == 'string' then
     out = element
@@ -82,18 +88,18 @@ local function pandocAstParse(element)
   if type(element) == 'table' then
     out = {}
     if element.t then
-      if Pandoc[element.t] then
+      if self[element.t] then
         if HasMultipleArgs[element.t] then
-          addNodes(out, Pandoc[element.t](table.unpack(element.c)))
+          addNodes(out, self[element.t](self, table.unpack(element.c)))
         else
-          addNodes(out, Pandoc[element.t](element.c))
+          addNodes(out, self[element.t](self, element.c))
         end
       else
         SU.warn("Unrecognized Pandoc AST element "..element.t)
       end
     end
     for _, b in ipairs(element) do
-      addNodes(out, pandocAstParse(b))
+      addNodes(out, self:render(b))
     end
   end
   --  Simplify output by removing useless grouping
@@ -162,26 +168,26 @@ end
 
 -- Plain [Inline]
 -- (not a paragraph)
-Pandoc.Plain = function (inlines)
-  return pandocAstParse(inlines)
+function Renderer:Plain (inlines)
+  return self:render(inlines)
 end
 
 -- Para [Inline]
-Pandoc.Para = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Para (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("markdown:internal:paragraph", {}, content)
 end
 
 -- LineBlock [[Inline]]
-Pandoc.LineBlock = function (lines)
+function Renderer:LineBlock (lines)
   local buffer = {}
   for _, inlines in ipairs(lines) do
     local level, currated_inlines = extractLineBlockLevel(inlines)
     -- Let's be typographically sound and use quad kerns rather than spaces for indentation
     local contents = (level > 0) and {
       utils.createCommand("kern", { width = level.."em" }),
-      pandocAstParse(currated_inlines)
-    } or pandocAstParse(currated_inlines)
+      self:render(currated_inlines)
+    } or self:render(currated_inlines)
     if #contents == 0 then
       buffer[#buffer+1] = utils.createCommand("stanza", {})
     else
@@ -193,19 +199,19 @@ end
 
 -- CodeBlock Attr Text
 -- Code block (literal) with attributes
-Pandoc.CodeBlock = function (attributes, text)
+function Renderer.CodeBlock (_, attributes, text)
   local options = pandocAttributes(attributes)
   return utils.createCommand("markdown:internal:codeblock", options, text)
 end
 
 -- RawBlock Format Text
-Pandoc.RawBlock = function (format, text)
+function Renderer.RawBlock (_, format, text)
   return utils.createCommand("markdown:internal:rawblock", { format = format }, text)
 end
 
 -- BlockQuote [Block]
-Pandoc.BlockQuote = function (blocks)
-  local content = pandocAstParse(blocks)
+function Renderer:BlockQuote (blocks)
+  local content = self:render(blocks)
   return utils.createCommand("markdown:internal:blockquote", {}, content)
 end
 
@@ -225,7 +231,7 @@ local pandocListNumberDelimTags = {
   Period = { after ="." },
   TwoParens = { before = "(", after = ")" }
 }
-Pandoc.OrderedList = function (listattrs, itemblocks)
+function Renderer:OrderedList (listattrs, itemblocks)
   -- ListAttributes = (Int, ListNumberStyle, ListNumberDelim)
   --   Where ListNumberStyle, ListNumberDelim) are tags
   local start, style, delim = table.unpack(listattrs)
@@ -242,29 +248,29 @@ Pandoc.OrderedList = function (listattrs, itemblocks)
 
   local contents = {}
   for i = 1, #itemblocks do
-    contents[i] = utils.createCommand("item", {}, pandocAstParse(itemblocks[i]))
+    contents[i] = utils.createCommand("item", {}, self:render(itemblocks[i]))
   end
   return utils.createStructuredCommand("enumerate", options, contents)
 end
 
 -- BulletList [[Block]]
 -- Bullet list (list of items, each a list of blocks)
-Pandoc.BulletList = function (itemblocks)
+function Renderer:BulletList (itemblocks)
   local contents = {}
   for i = 1, #itemblocks do
     local blocks = itemblocks[i]
     local options = { bullet = extractTaskListBullet(blocks) }
-    contents[i] = utils.createCommand("item", options, pandocAstParse(blocks))
+    contents[i] = utils.createCommand("item", options, self:render(blocks))
   end
   return utils.createStructuredCommand("itemize", {}, contents)
 end
 
 -- DefinitionList [([Inline], [[Block]])]
-Pandoc.DefinitionList = function (items)
+function Renderer:DefinitionList (items)
   local buffer = {}
   for _, item in ipairs(items) do
-    local term = pandocAstParse(item[1])
-    local definition = pandocAstParse(item[2])
+    local term = self:render(item[1])
+    local definition = self:render(item[2])
     buffer[#buffer + 1] = utils.createCommand("markdown:internal:term", {}, term)
     buffer[#buffer + 1] = utils.createStructuredCommand("markdown:internal:definition", {}, definition)
   end
@@ -272,24 +278,24 @@ Pandoc.DefinitionList = function (items)
 end
 
 -- Header Int Attr [Inline]
-Pandoc.Header = function (level, attributes, inlines)
+function Renderer:Header (level, attributes, inlines)
   local options = pandocAttributes(attributes)
-  local content = pandocAstParse(inlines)
+  local content = self:render(inlines)
   options.level = level
   return utils.createCommand("markdown:internal:header", options, content)
 end
 
 -- HorizontalRule
 -- Horizontal rule
-Pandoc.HorizontalRule = function ()
+function Renderer.HorizontalRule (_)
   return utils.createCommand("fullrule") -- No way to customize it.
 end
 
 -- Div Attr [Block]
 -- Generic block container with attributes
-Pandoc.Div = function (attributes, blocks)
+function Renderer:Div (attributes, blocks)
   local options = pandocAttributes(attributes)
-  local content = pandocAstParse(blocks)
+  local content = self:render(blocks)
   return utils.createCommand("markdown:internal:div" , options, content)
 end
 
@@ -301,7 +307,7 @@ local pandocAlignmentTags = {
 }
 
 -- Cell Attr Alignment RowSpan:Int ColSpan:Int [Block]
-local function pandocCell (cell, colalign)
+function Renderer:pandocCell (cell, colalign)
   local _, align, rowspan, colspan, blocks = table.unpack(cell)
   if rowspan ~= 1 then
     -- Not doable without pain, ptable has cell splitting but no row spanning.
@@ -310,22 +316,22 @@ local function pandocCell (cell, colalign)
   end
   local cellalign = pandocAlignmentTags[align.t]
   local halign = cellalign ~= "default" and cellalign or colalign
-  return utils.createCommand("cell", { valign="middle", halign = halign, span = colspan }, pandocAstParse(blocks))
+  return utils.createCommand("cell", { valign="middle", halign = halign, span = colspan }, self:render(blocks))
 end
 
 -- Row Attr [Cell]
-local function pandocRow (row, colaligns, options)
+function Renderer:pandocRow (row, colaligns, options)
   local cells = row[2]
   local cols = {}
   for i, cell in ipairs(cells) do
-    local col = pandocCell(cell, colaligns[i])
+    local col = self:pandocCell(cell, colaligns[i])
     cols[#cols+1] = col
   end
   return utils.createStructuredCommand("row", options or {}, cols)
 end
 
 -- Table Attr Caption [ColSpec] TableHead [TableBody] TableFoot
-Pandoc.Table = function (_, caption, colspecs, thead, tbodies, tfoot)
+function Renderer:Table (_, caption, colspecs, thead, tbodies, tfoot)
   -- CAVEAT: This goes far beyond what Markdown needs (quite logically, Pandoc
   -- supporting  other formats) and can be hard to map to SILE's ptable package.
   local aligns = {}
@@ -341,7 +347,7 @@ Pandoc.Table = function (_, caption, colspecs, thead, tbodies, tfoot)
   local hasHeader = false
   for _, row in ipairs(thead[2]) do
     hasHeader = true
-    ptableRows[#ptableRows+1] = pandocRow(row, aligns, { background = "#eee"})
+    ptableRows[#ptableRows+1] = self:pandocRow(row, aligns, { background = "#eee"})
   end
 
   -- TableBody Attr RowHeadColumns [Row] [Row]
@@ -350,13 +356,13 @@ Pandoc.Table = function (_, caption, colspecs, thead, tbodies, tfoot)
   for _, tbody in ipairs(tbodies) do
     if tbody[2] ~= 0 then SU.error("Pandoc AST tables with several head columns are not sup ported") end
     for _, row in ipairs(tbody[4]) do
-      ptableRows[#ptableRows+1] = pandocRow(row, aligns)
+      ptableRows[#ptableRows+1] = self:pandocRow(row, aligns)
     end
   end
 
   -- TableFoot Attr [Row]
   for _, row in ipairs(tfoot[2]) do
-    ptableRows[#ptableRows+1] = pandocRow(row, aligns)
+    ptableRows[#ptableRows+1] = self:pandocRow(row, aligns)
   end
 
   local cWidth = {}
@@ -381,7 +387,7 @@ Pandoc.Table = function (_, caption, colspecs, thead, tbodies, tfoot)
   end
   local captioned = {
     ptable,
-    utils.createCommand("caption", {}, pandocAstParse(caption[#caption]))
+    utils.createCommand("caption", {}, self:render(caption[#caption]))
   }
   return utils.createStructuredCommand("markdown:internal:captioned-table", {}, captioned)
 end
@@ -389,55 +395,55 @@ end
 -- PANDOC AST INLINES
 
 -- Str Text
-Pandoc.Str = function (text)
+function Renderer.Str (_, text)
   return utils.nbspFilter(text)
 end
 
 -- Emph [Inline]
-Pandoc.Emph =  function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Emph (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("em", {}, content)
 end
 -- Underline [Inline]
-Pandoc.Underline = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Underline (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("underline", {}, content)
 end
 
 -- Strong [Inline]
-Pandoc.Strong = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Strong (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("strong", {}, content)
 end
 
 -- Strikeout [Inline]
-Pandoc.Strikeout = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Strikeout (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("strikethrough", {}, content)
 end
 
 -- Superscript [Inline]
-Pandoc.Superscript = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Superscript (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("textsuperscript", {}, content)
 end
 
 -- Subscript [Inline]
-Pandoc.Subscript = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Subscript (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("textsubscript", {}, content)
 end
 
 -- SmallCaps [Inline]
-Pandoc.SmallCaps = function (inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:SmallCaps (inlines)
+  local content = self:render(inlines)
   return utils.createCommand("font", { features = "+smcp" }, content)
 end
 
 -- Quoted QuoteType [Inline]
 --   Where QuoteType is a tag DoubleQuote or SingleQuote
-Pandoc.Quoted = function (quotetype, inlines)
-  local content = pandocAstParse(inlines)
+function Renderer:Quoted (quotetype, inlines)
+  local content = self:render(inlines)
   if quotetype.t == "DoubleQuote" then
     return utils.createCommand("doublequoted", {}, content)
   end
@@ -446,61 +452,61 @@ end
 
 -- Cite [Citation] [Inline]
 --   Where a Citation is a dictionary
-Pandoc.Cite = function (_, inlines)
+function Renderer:Cite (_, inlines)
   -- TODO
   -- We could possibly do better.
   -- Just render the inlines and ignore the citations
-  return pandocAstParse(inlines)
+  return self:render(inlines)
 end
 
 -- Code Attr Text
-Pandoc.Code = function (attributes, text)
+function Renderer.Code (_, attributes, text)
   local options = pandocAttributes(attributes)
   return utils.createCommand("code", options, text)
 end
 
 -- Space
-Pandoc.Space = function ()
+function Renderer.Space (_)
   return " "
 end
 
 -- SoftBreak
-Pandoc.SoftBreak = function ()
+function Renderer.SoftBreak (_)
   return " " -- Yup.
 end
 
 -- LineBreak
 -- Hard line break
-Pandoc.LineBreak = function ()
+function Renderer.LineBreak (_)
   return utils.createCommand("cr")
 end
 
 -- Math MathType Text
 -- TeX math (literal)
-Pandoc.Math = function (mathtype, text)
+function Renderer.Math (_, mathtype, text)
   local mode = (mathtype.t and mathtype.t == "DisplayMath") and "display" or "text"
   return utils.createCommand("markdown:internal:math" , { mode = mode }, { text })
 end
 
 -- RawInline Format Text
-Pandoc.RawInline = function (format, text)
+function Renderer.RawInline (_, format, text)
   return utils.createCommand("markdown:internal:rawinline", { format = format }, text)
 end
 
 -- Link Attr [Inline] Target
-Pandoc.Link = function (attributes, inlines, target) -- attributes, inlines, target
+function Renderer:Link (attributes, inlines, target) -- attributes, inlines, target
   local options = pandocAttributes(attributes)
   -- Target = (Url : Text, Title : Text)
   local uri, _ = table.unpack(target) -- uri, title (unused too?)
   options.src = uri
-  local content = pandocAstParse(inlines)
+  local content = self:render(inlines)
   return utils.createCommand("markdown:internal:link", options, content)
 end
 
 -- Image Attr [Inline] Target
-Pandoc.Image = function (attributes, inlines, target) -- attributes, inlines, target
+function Renderer:Image (attributes, inlines, target) -- attributes, inlines, target
   local options = pandocAttributes(attributes)
-  local content = pandocAstParse(inlines)
+  local content = self:render(inlines)
   -- Target = (Url : Text, Title : Text)
   local uri, _ = table.unpack(target)
   options.src = uri
@@ -508,15 +514,15 @@ Pandoc.Image = function (attributes, inlines, target) -- attributes, inlines, ta
 end
 
 -- Note [Block]
-Pandoc.Note = function (blocks)
-  local content = pandocAstParse(blocks)
+function Renderer:Note (blocks)
+  local content = self:render(blocks)
   return utils.createCommand("markdown:internal:footnote", {}, content)
 end
 
 -- Span Attr [Inline]
-Pandoc.Span = function (attributes, inlines)
+function Renderer:Span (attributes, inlines)
   local options = pandocAttributes(attributes)
-  local content = pandocAstParse(inlines)
+  local content = self:render(inlines)
   return utils.createCommand("markdown:internal:span" , options, content)
 end
 
@@ -551,7 +557,7 @@ function inputter.appropriate (round, filename, doc)
   return false
 end
 
-function inputter.parse (_, doc)
+function inputter:parse (doc)
   local has_json, json = pcall(require, "json.decode")
   if not has_json then
     SU.error("The pandocast inputter requires LuaJSON's json.decode() to be available.")
@@ -562,7 +568,8 @@ function inputter.parse (_, doc)
   local PANDOC_API_VERSION = ast['pandoc-api-version']
   checkAstSemver(PANDOC_API_VERSION)
 
-  local tree = pandocAstParse(ast.blocks)
+  local renderer = Renderer(self.options)
+  local tree = renderer:render(ast.blocks)
 
   -- The Markdown parsing returns a SILE AST.
   -- Wrap it in a document structure so we can just process it, and if at

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -44,7 +44,7 @@ local utils = require("packages.markdown.utils")
 local Renderer = pl.class()
 
 function Renderer:_init(options)
-  self.shiftheaders = SU.cast("integer", options.shiftheaders or 0)
+  self.shift_headings = SU.cast("integer", options.shift_headings or 0)
 end
 
 -- Allows unpacking tables on some Pandoc AST nodes so as to map them to methods
@@ -281,7 +281,7 @@ end
 function Renderer:Header (level, attributes, inlines)
   local options = pandocAttributes(attributes)
   local content = self:render(inlines)
-  options.level = level
+  options.level = level + self.shift_headings
   return utils.createCommand("markdown:internal:header", options, content)
 end
 

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -35,15 +35,16 @@ local CommandCascade = pl.class({
   end,
 })
 
-local UsualSectioning = { "chapter", "section", "subsection", "subsubsection" }
+local UsualSectioning = { "part", "chapter", "section", "subsection", "subsubsection" }
 local function getSectioningCommand (level)
-  if level <= #UsualSectioning then
+  local index = level + 1
+  if index > 0 and index <= #UsualSectioning then
     -- Check we actually have those commands (e.g. some classes might not
     -- have subsubsections.)
-    if SILE.Commands[UsualSectioning[level]] then
-      return UsualSectioning[level]
+    if SILE.Commands[UsualSectioning[index]] then
+      return UsualSectioning[index]
     end
-    SU.warn("Unknown command \\"..UsualSectioning[level].." (fallback to a default generic header)")
+    SU.warn("Unknown command \\"..UsualSectioning[index].." (fallback to a default generic header)")
     -- Default to something anyway.
     return "markdown:fallback:header"
   end


### PR DESCRIPTION
Inputter option `shift_headings`:
- [x] implementation
- [x] documentation