### PR TITLE
Minor tweaks and backported fixes

### DIFF
--- a/examples/sile-and-markdown-manual.sil
+++ b/examples/sile-and-markdown-manual.sil
@@ -16,7 +16,7 @@
 \set[parameter=document.parskip, value=2pt]
 \language[main=en]
 \footnote:rule%
-\pdf:metadata[key=Title, value=Markdown to PDF with SILE]
+\pdf:metadata[key=Title, value=Markdown and Djot to PDF with SILE]
 \pdf:metadata[key=Author, value=Didier Willis]
 %
 % Quick and dirty title page and front matter
@@ -147,7 +147,7 @@ our package might not support them well. Its main focus is on Markdown parity wi
 
 \include[src=pandoc-tables.pandoc]
 
-\include[src=sile-and-djot.dj, meta:title=Markdown to PDF with SILE]
+\include[src=sile-and-djot.dj, meta:title=Markdown and Djot to PDF with SILE]
 
 \include[src=sile-and-pandoc.dj]
 

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -538,7 +538,7 @@ local predefinedSymbols = {
   _TOC_ = {
     standalone = true,
     render = function (node)
-      return utils.createCommand("tableofcontents", node.attr)
+      return utils.createCommand("markdown:internal:toc", node.attr)
     end
   },
   _FANCYTOC_ = { -- of course, requires having installed the fancytoc.sile module

--- a/lua-libraries/djot/block.lua
+++ b/lua-libraries/djot/block.lua
@@ -27,9 +27,9 @@ local function get_list_styles(marker)
     return {(marker:gsub("%d+","1"))}
   -- in ambiguous cases we return two values
   elseif find(marker, "^[(]?[ivxlcdm][).]") then
-    return {(marker:gsub("%a+", "a")), (marker:gsub("%a+", "i"))}
+    return {(marker:gsub("%a+", "i")), (marker:gsub("%a+", "a"))}
   elseif find(marker, "^[(]?[IVXLCDM][).]") then
-    return {(marker:gsub("%a+", "A")), (marker:gsub("%a+", "I"))}
+    return {(marker:gsub("%a+", "I")), (marker:gsub("%a+", "A"))}
   elseif find(marker, "^[(]?%l[).]") then
     return {(marker:gsub("%l", "a"))}
   elseif find(marker, "^[(]?%u[).]") then

--- a/lua-libraries/lunamark/reader/markdown.lua
+++ b/lua-libraries/lunamark/reader/markdown.lua
@@ -1385,11 +1385,9 @@ function M.new(writer, options)
   larsers.FencedDiv = parsers.fenced_div_begin * increment_div_level(1)
                     * parsers.skipblanklines
                     * Ct( (V("Block") - parsers.fenced_div_end)^-1
-                        * (parsers.blanklines / function()
-                                              return writer.interblocksep
-                                            end
+                        * ( V("Blank")^0 / writer.interblocksep
                           * (V("Block") - parsers.fenced_div_end))^0)
-                    * parsers.skipblanklines
+                    * V("Blank")^0
                     * parsers.fenced_div_end * increment_div_level(-1)
                     / function (infostring, div)
                         local attr = lpeg.match(Cg(parsers.attributes), infostring)

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -679,6 +679,24 @@ Please consider using a resilient-compatible class!]])
     end
   end, "Captioned blockquote in Djot (internal)")
 
+  self:registerCommand("markdown:internal:toc", function (options, _)
+    if not SILE.Commands["tableofcontents"] then
+      SU.warn("No table of contents command available (skipped)")
+      return
+    end
+    local tocHeaderCmd = SILE.Commands["tableofcontents:header"]
+    if tocHeaderCmd then
+      -- HACK (opinionated)
+      -- By design, resilient.tableofcontents does not output a header.
+      -- In case the standard tableofcontents package from the SILE core
+      -- distribution is used, then we temporarily cancel its header,
+      -- so we get the same behavior in whatever case.
+      SILE.Commands["tableofcontents:header"] = function () end
+    end
+    SILE.call("tableofcontents", options)
+    SILE.Commands["tableofcontents:header"] = tocHeaderCmd
+  end, "Table of contents in Djot (internal)")
+
   -- B. Fallback commands
 
   self:registerCommand("markdown:fallback:blockquote", function (_, content)


### PR DESCRIPTION
- Closes #82 (backport)
- Closes #85 (backport)
- Update PDF metadata in the manual
- (Djot) Cancel SILE's ToC header for feature parity whether using SILE's core ToC and resilient's ToC packages