### PR TITLE
feat: improve resilient class detection

### DIFF
--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -133,9 +133,9 @@ end
 function package:_init (_)
   base._init(self)
 
-  -- HACK very lame detection
-  -- Try to guess if the resilient classes are used
-  self.isResilient = self.class._name:match("^resilient")
+  -- Check if document class is a resilient class or derived from one
+  local ok, ResilientBase = pcall(require, 'classes.resilient.base')
+  self.isResilient = ok and self.class:is_a(ResilientBase)
 
   -- Only load low-level packages (= utilities)
   -- The class should be responsible for loading the appropriate higher-level


### PR DESCRIPTION
I have tested it on the default class and a `classes.test` class defined as follows:

```lua
local book = require("classes.resilient.book")
local class = pl.class(book)
class._name = "test"

function class:_init (options)
  book._init(self, options)

  self:loadPackage("markdown")
end

return class
```

As an input file, I used this short `hello.md`:

```markdown
# Hello {#hello}
Hello, world!
```

When I ran `sile -u inputters.markdown hello.md` and `sile -u inputters.markdown -c classes.test hello.md`, then in the first case I got a non-resilient class warning and in the second case I got none.