### PR TITLE
Improve Lua 5.1 compatibility, lint for 5.1 issues

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-std = "max+sile"
+std = "min+sile"
 include_files = {
   "**/*.lua",
   "sile.in",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-std = "max"
+std = "max+sile"
 include_files = {
   "**/*.lua",
   "sile.in",
@@ -18,15 +18,6 @@ exclude_files = {
 }
 files["**/*_spec.lua"] = {
   std = "+busted"
-}
-globals = {
-  "SILE",
-  "SU",
-  "luautf8",
-  "pl",
-  "fluent",
-  "SYSTEM_SILE_PATH",
-  "SHARED_LIB_EXT"
 }
 max_line_length = false
 ignore = {

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -50,7 +50,7 @@ local function extractLineBlockLevel (inlines)
   if f and type(f) == "string" then
     local line = f
     line = line:gsub("^[ ]+", function (match) -- Warning, U+00A0 here.
-      level = utf8.len(match)
+      level = luautf8.len(match)
       return ""
     end)
     if line == "" then -- and #inlines == 1 then

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -21,8 +21,8 @@ local utils = require("packages.markdown.utils")
 local function checkAstSemver(version)
   -- We shouldn't care the patch level.
   -- The Pandoc AST may change upon "minor" updates, though.
-  local major, minor = table.unpack(version)
-  local expected_major, expected_minor = table.unpack(Pandoc.API_VERSION)
+  local major, minor = pl.utils.unpack(version)
+  local expected_major, expected_minor = pl.utils.unpack(Pandoc.API_VERSION)
   if not major or major ~= expected_major then
     SU.error("Unsupported Pandoc AST major version " .. major
       .. ", only version " .. expected_major.. " is supported")
@@ -84,7 +84,7 @@ local function pandocAstParse(element)
     if element.t then
       if Pandoc[element.t] then
         if HasMultipleArgs[element.t] then
-          addNodes(out, Pandoc[element.t](table.unpack(element.c)))
+          addNodes(out, Pandoc[element.t](pl.utils.unpack(element.c)))
         else
           addNodes(out, Pandoc[element.t](element.c))
         end
@@ -109,7 +109,7 @@ end
 --   Lua custom writer would expose, and which also looks like regular SILE
 --   options.
 local function pandocAttributes(attributes)
-  local id, class, keyvals = table.unpack(attributes)
+  local id, class, keyvals = pl.utils.unpack(attributes)
   local options = {
     id = id and id ~= "" and id or nil,
     class = table.concat(class, " "),
@@ -135,7 +135,7 @@ local function extractLineBlockLevel (inlines)
     -- Or any other inline content if there are not leading spaces.
     local line = f.c
     line = line:gsub("^[ ]+", function (match) -- Warning, U+00A0 here.
-      level = utf8.len(match)
+      level = luautf8.len(match)
       return ""
     end)
     f.c = line -- replace
@@ -228,7 +228,7 @@ local pandocListNumberDelimTags = {
 Pandoc.OrderedList = function (listattrs, itemblocks)
   -- ListAttributes = (Int, ListNumberStyle, ListNumberDelim)
   --   Where ListNumberStyle, ListNumberDelim) are tags
-  local start, style, delim = table.unpack(listattrs)
+  local start, style, delim = pl.utils.unpack(listattrs)
   local display = pandocListNumberStyleTags[style.t]
   local delimiters = pandocListNumberDelimTags[delim.t]
   local options = {
@@ -302,7 +302,7 @@ local pandocAlignmentTags = {
 
 -- Cell Attr Alignment RowSpan:Int ColSpan:Int [Block]
 local function pandocCell (cell, colalign)
-  local _, align, rowspan, colspan, blocks = table.unpack(cell)
+  local _, align, rowspan, colspan, blocks = pl.utils.unpack(cell)
   if rowspan ~= 1 then
     -- Not doable without pain, ptable has cell splitting but no row spanning.
     -- We'd have to handle this very differently.
@@ -491,7 +491,7 @@ end
 Pandoc.Link = function (attributes, inlines, target) -- attributes, inlines, target
   local options = pandocAttributes(attributes)
   -- Target = (Url : Text, Title : Text)
-  local uri, _ = table.unpack(target) -- uri, title (unused too?)
+  local uri, _ = pl.utils.unpack(target) -- uri, title (unused too?)
   options.src = uri
   local content = pandocAstParse(inlines)
   return utils.createCommand("markdown:internal:link", options, content)
@@ -502,7 +502,7 @@ Pandoc.Image = function (attributes, inlines, target) -- attributes, inlines, ta
   local options = pandocAttributes(attributes)
   local content = pandocAstParse(inlines)
   -- Target = (Url : Text, Title : Text)
-  local uri, _ = table.unpack(target)
+  local uri, _ = pl.utils.unpack(target)
   options.src = uri
   return utils.createCommand("markdown:internal:image", options, content)
 end

--- a/markdown.sile-dev-1.rockspec
+++ b/markdown.sile-dev-1.rockspec
@@ -15,6 +15,7 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
+   "penlight >= 1.13.0", -- use of kpairs requires newer Penlight than transitive dependency possibly provided by SILE
    "embedders.sile",
    "labelrefs.sile",
    "ptable.sile",


### PR DESCRIPTION
I was trying to use this for something and ran into trouble. It turns out at the very least one issue was my SILE runs on LuaJIT and this library was making assumptions about access to Lua 5.4 interfaces. SILE provides shims for things like that it wants to use that were introduced to Lua later, and also grantees access to Penlight and some other libraries. By calling those libraries we know SILE provides we should be able to make this 5.1 compatible.

Also Luacheck provides upstream support for SILE's builtin variables. This makes use of that and then lints against 5.1 (min) instead of 5.4 (max).
