### PR TITLE
fix: Do not load the resilient base class for feature detection

### DIFF
--- a/markdown.sile-1.5.2-1.rockspec
+++ b/markdown.sile-1.5.2-1.rockspec
@@ -1,0 +1,60 @@
+rockspec_format = "3.0"
+package = "markdown.sile"
+version = "1.5.2-1"
+source = {
+    url = "git+https://github.com/Omikhleia/markdown.sile.git",
+    tag = "v1.5.2",
+}
+description = {
+  summary = "Native Markdown support for the SILE typesetting system.",
+  detailed = [[
+    This package set for the SILE typesetting system provides a complete redesign
+    of the native Markdown support for SILE, with a great set of Pandoc-like
+    extensions and plenty of extra goodies.
+  ]],
+  homepage = "https://github.com/Omikhleia/markdown.sile",
+  license = "MIT",
+}
+dependencies = {
+   "lua >= 5.1",
+   "embedders.sile >= 0.1.0",
+   "labelrefs.sile >= 0.1.0",
+   "ptable.sile >= 2.0.2",
+   "smartquotes.sile >= 1.0.0",
+   "textsubsuper.sile >= 1.1.1",
+   "silex.sile >= 0.4.0",
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      ["sile.classes.markdown"]           = "classes/markdown.lua",
+      ["sile.inputters.markdown"]         = "inputters/markdown.lua",
+      ["sile.inputters.pandocast"]        = "inputters/pandocast.lua",
+      ["sile.inputters.djot"]             = "inputters/djot.lua",
+      ["sile.packages.markdown"]          = "packages/markdown/init.lua",
+      ["sile.packages.markdown.commands"] = "packages/markdown/commands.lua",
+      ["sile.packages.markdown.utils"]    = "packages/markdown/utils.lua",
+      ["sile.packages.pandocast"]         = "packages/pandocast/init.lua",
+      ["sile.packages.djot"]              = "packages/djot/init.lua",
+
+      ["sile.lunamark"]                 = "lua-libraries/lunamark.lua",
+      ["sile.lunamark.entities"]        = "lua-libraries/lunamark/entities.lua",
+      ["sile.lunamark.reader"]          = "lua-libraries/lunamark/reader.lua",
+      ["sile.lunamark.reader.markdown"] = "lua-libraries/lunamark/reader/markdown.lua",
+      ["sile.lunamark.util"]            = "lua-libraries/lunamark/util.lua",
+      ["sile.lunamark.writer"]          = "lua-libraries/lunamark/writer.lua",
+      ["sile.lunamark.writer.generic"]  = "lua-libraries/lunamark/writer/generic.lua",
+      ["sile.lunamark.writer.html"]     = "lua-libraries/lunamark/writer/html.lua",
+      ["sile.lunamark.writer.html5"]    = "lua-libraries/lunamark/writer/html5.lua",
+
+      ["sile.djot"]                     = "lua-libraries/djot.lua",
+      ["sile.djot.attributes"]          = "lua-libraries/djot/attributes.lua",
+      ["sile.djot.json"]                = "lua-libraries/djot/json.lua",
+      ["sile.djot.block"]               = "lua-libraries/djot/block.lua",
+      ["sile.djot.inline"]              = "lua-libraries/djot/inline.lua",
+      ["sile.djot.html"]                = "lua-libraries/djot/html.lua",
+      ["sile.djot.ast"]                 = "lua-libraries/djot/ast.lua",
+      ["sile.djot.filter"]              = "lua-libraries/djot/filter.lua",
+   }
+}

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -147,12 +147,32 @@ function package:loadPackageAlt(resilientpack, legacypack)
   end
 end
 
+-- For feature detection.
+-- NOTE: The previous implementation was clever;
+--   local ok, ResilientBase = pcall(require, 'classes.resilient.base')
+--   return ok and self.class:is_a(ResilientBase)
+-- However this loads the class, which loads all the silex extensions, even if
+-- the class is not used...
+-- Enforcing the silex extensions is not what we wanted.
+-- So we are back to a more naive implementation, checking the class hierarchy
+-- by name.
+-- This is lame and knows too much about internals, but heh.
+local function isResilientClass(cl)
+  while cl do
+    if cl._name == "resilient.base" then
+      return true
+    end
+    cl = cl._base
+  end
+  return false
+end
+
 function package:_init (_)
   base._init(self)
 
   -- Check if document class is a resilient class or derived from one
-  local ok, ResilientBase = pcall(require, 'classes.resilient.base')
-  self.isResilient = ok and self.class:is_a(ResilientBase)
+  self.isResilient = isResilientClass(self.class)
+  SU.debug("markdown", self.isResilient and "Used in a resilient class" or "Used in a non-resilient class")
 
   -- Only load low-level packages (= utilities)
   -- The class should be responsible for loading the appropriate higher-level


### PR DESCRIPTION
It loaded the whole of the extensions provided by silex.sile, which is not what we wanted outside the resilient usage. It behaves badly with silex.sile 0.4 as overrides would now come too late possibly, causing havoc...

A quick workaround for #107 which would deserve a cleaner solution...