### PR TITLE
feat(pandocast): Support the lunajson parsing library as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ Some *Djot* content
 
 ### Pandoc AST alternative package
 
-_Prerequisites:_ The [LuaJSON](https://github.com/harningt/luajson) module must be installed and available to your SILE environment.
-This topic is not covered here.
+This experimental package allows to convert Pandoc JSON AST files directly to PDF documents.
 
-First, using the appropriate version of Pandoc, convert your file to a JSON AST:
+Using the appropriate version of Pandoc, convert your file to a JSON AST:
 
 ```shell
 pandoc -t json somefile.md -f markdown -o somefile.pandoc

--- a/examples/sile-and-pandoc.dj
+++ b/examples/sile-and-pandoc.dj
@@ -13,8 +13,13 @@ The following solution is still an experimental proof-of-concept, but you may gi
 ## Prerequisites
 
 Obviously, you need to have the Pandoc software installed on your system.
-You also need to have the LuaJSON module installed and available to your SILE environment.
-As of 2024, we recommend using the development version of the module, due to some issues with the current release version.
+You also need a JSON parser, and this collection comes by default with the *lunajson* module as pre-installed dependency.
+It is a Lua-only module, with no external dependencies, so it works out of the box.
+
+Another option is to use the *luajson* module, which is an LPeg-based parser, and might (or not) be more efficient in some cases.
+On some systems, it may however require the LPeg library to be compiled and installed.
+Luarocks{.nobreak} should take care of that for you, but it then assumes you have the necessary development tools on your system.
+Moreover, as of 2024, the current release version of the module has some issues, so we recommend using the development version instead:
 
 {custom-style=CodeBlock}
 :::
@@ -22,6 +27,8 @@ As of 2024, we recommend using the development version of the module, due to som
 luarocks install --dev luajson
 ```
 :::
+
+If you have *luajson* installed, it is used instead of the default *lunajson* dependency.
 
 ## Using Pandoc's AST with the pandocast package
 

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -6,7 +6,7 @@
 -- AST conversion relies on the Pandoc types specification:
 -- https://hackage.haskell.org/package/pandoc-types
 --
--- Using the LuaJSON library for parsing.
+-- Using the luajson (LPEG-based) or lunajson (pure Lua) library for parsing.
 -- Reusing the common commands initially made for the "markdown" inputter/package.
 --
 -- @copyright License: MIT (c) 2022-2024 Omikhleia, Didier Willis
@@ -582,9 +582,16 @@ function inputter.appropriate (round, filename, doc)
 end
 
 function inputter:parse (doc)
+  -- Load JSON parser:
+  -- Luajson is LPEG-based, and lunajson is pure Lua without other
+  -- dependencies. Prioritize the former for if available, otherwise
+  -- fallback to lunajson, which we'll have in our dependencies.
   local has_json, json = pcall(require, "json.decode")
   if not has_json then
-    SU.error("The pandocast inputter requires LuaJSON's json.decode() to be available.")
+    has_json, json = pcall(require, "lunajson")
+    if not has_json then
+      SU.error("The pandocast inputter requires either luajson or lunajson to be available.")
+    end
   end
 
   local jsast = json.decode(doc)

--- a/rockspecs/markdown.sile-2.2.0-1.rockspec
+++ b/rockspecs/markdown.sile-2.2.0-1.rockspec
@@ -1,8 +1,9 @@
 rockspec_format = "3.0"
 package = "markdown.sile"
-version = "dev-1"
+version = "2.2.0-1"
 source = {
     url = "git+https://github.com/Omikhleia/markdown.sile.git",
+    tag = "v2.2.0",
 }
 description = {
   summary = "Native Markdown support for the SILE typesetting system.",
@@ -16,12 +17,12 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "embedders.sile",
-   "labelrefs.sile",
-   "ptable.sile",
-   "smartquotes.sile",
-   "textsubsuper.sile",
-   "silex.sile",
+   "embedders.sile >= 0.2.0",
+   "labelrefs.sile >= 0.1.0",
+   "ptable.sile >= 3.1.0",
+   "smartquotes.sile >= 1.0.0",
+   "textsubsuper.sile >= 1.1.1",
+   "silex.sile >= 0.6.0, < 1.0",
    "lunajson",
 }
 


### PR DESCRIPTION
Alternative to luajson for JSON parsing.

Closes #104

Closes #21 

The documentation now says what to do for luajson; and lunajson as Lua-only module also works and will be made the default dependency.