### PR TITLE
fix: Always wrap tables in captioned-table and let the latter handle …

### DIFF
--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -320,14 +320,11 @@ function Renderer:table (node)
      header = SU.boolean(row.head, false),
   }, self:render_children(node), pos)
 
-  if not caption then
-    return ptable
-  end
-  local captioned = {
+  local wrapped = caption and {
     ptable,
     createCommand("caption", {}, caption, pos)
-  }
-  return createStructuredCommand("markdown:internal:captioned-table", options, captioned, pos)
+  } or { ptable }
+  return createStructuredCommand("markdown:internal:captioned-table", options, wrapped, pos)
 end
 
 function Renderer:row (node)

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -218,15 +218,11 @@ local function SileAstWriter (writerOps, renderOps)
     end
     local ptable = createStructuredCommand("ptable", { header = true, cols = table.concat(cWidth, " ") }, ptableRows)
 
-    if not caption then
-      return ptable
-    end
-
-    local captioned = {
+    local wrapped = caption and {
       ptable,
       createCommand("caption", {}, caption)
-    }
-    return createStructuredCommand("markdown:internal:captioned-table", {}, captioned)
+    } or { ptable }
+    return createStructuredCommand("markdown:internal:captioned-table", {}, wrapped)
   end
 
   writer.definitionlist = function (items, _) -- items, tight

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -408,15 +408,13 @@ function Renderer:Table (_, caption, colspecs, thead, tbodies, tfoot)
   }, ptableRows)
 
   -- Caption (Maybe ShortCaption) [Block]
-  if not caption or #caption[#caption] == 0 then
-    -- No block or empty block = no caption...
-    return ptable
-  end
-  local captioned = {
+  -- No block or empty block = no caption..
+  local hasCaption = caption and #caption[#caption] > 0
+  local wrapped = hasCaption and {
     ptable,
     createCommand("caption", {}, self:render(caption[#caption]))
-  }
-  return createStructuredCommand("markdown:internal:captioned-table", {}, captioned)
+  } or { ptable }
+  return createStructuredCommand("markdown:internal:captioned-table", {}, wrapped)
 end
 
 -- Figure Attr Caption [Block]

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -898,8 +898,8 @@ Please consider using a resilient-compatible class!]])
       }, function ()
         SILE.call("center", {}, caption)
       end)
+      SILE.call("smallskip")
     end
-    SILE.call("smallskip")
   end, "A fallback command for Markdown to insert a captioned table")
 
   self:registerCommand("markdown:fallback:defn", function (_, content)


### PR DESCRIPTION
…a caption

The captioned-table environment (whether from resilient.book or using the fallback) always supported tables without caption. It's better to always wrap tables into it, so styling (in resilient's use case) is applied, rather than return a raw ptable.

See https://github.com/Omikhleia/resilient.sile/issues/103 for the rationale and discussion.