### PR TITLE
fix: Propagate Djot attributes to the blockquote implementation

### DIFF
--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -199,7 +199,7 @@ function Renderer:blockquote (node)
       createCommand("caption", {}, caption)
     }, pos)
   else
-    out = createCommand("markdown:internal:blockquote", {}, content, pos)
+    out = createCommand("markdown:internal:blockquote", node.attr or {}, content, pos)
   end
   if node.attr then
     -- Add a div when containing attributes

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -618,18 +618,19 @@ Please consider using a resilient-compatible class!]])
     end
   end, "Raw native block in Markdown (internal)")
 
-  self:registerCommand("markdown:internal:blockquote", function (_, content)
-    -- Would be nice NOT having to do this, but SILE's plain class only has a "quote"
-    -- environment that doesn't really nest, and hard-codes all its values, skips, etc.
+  self:registerCommand("markdown:internal:blockquote", function (options, content)
+    -- NOTE: The comment below applies to SILE 0.14.x.
+    -- SILE's plain class only has a "quote" environment that doesn't really nest, and
+    -- hard-codes all its values, skips, etc.
     -- So we might have a better version provided by a user-class or package.
     -- Otherwise, use our own fallback (with hard-coded choices too, but a least
     -- it does some proper nesting)
-    -- NOTE: The above applies to SILE 0.14.x.
-    -- SILE 0.15 is expected to provide a blockquote environment.
+    -- SILE 0.15.0 provides a blockquote environment, so eventually this fallback
+    -- will be removed when we officially drop support for SILE 0.14.x.
     if not self.hasCommandSupport.blockquote then
-      SILE.call("markdown:fallback:blockquote", {}, content)
+      SILE.call("markdown:fallback:blockquote", options, content)
     else
-      SILE.call("blockquote", {}, content)
+      SILE.call("blockquote", options, content)
     end
   end, "Block quote in Markdown (internal)")
 


### PR DESCRIPTION
So the latter might implement a different behavior depending on them. As of now, SILE's default blockquote (from SILE 0.15.0) and resilient's style-aware blockquote don't support options, so this would not do anything yet, but it paves the way for more customization or alternate implementations.
N.B. It's also what we were already doing for the captioned quotes (via the epigraph environment, which does support several options), so it also fixes a small API discrepancy...

_Rationale:_
See discussion https://github.com/Omikhleia/markdown.sile/discussions/138