### PR TITLE
refactor!: Remove silex compatibility layer and some SILE shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,19 @@ luac.out
 # SILE artifacts
 *.toc
 *.ref
-tests/*.pdf
-tests/*.debug
+*.pdf
+*.idx
+*.debug
+**/converted/*
+**/embedded/*
 
 # I often have crappy test files here
 temp/*
 
+# LDoc if ran locally
+doc/*
+ldoc/*
+
+# Stuff copied or linked from lua_libraries/ to sile/
+# for hacking (as those files from lua_libraries/ are not in the sile namespace)
+sile/*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For casual readers, this collection notably aims at easily converting Djot or Ma
 
 ## Installation
 
-This module collection requires SILE v0.14 or upper (recommended: v0.15.10).
+This module collection requires SILE v0.15 (recommended: v0.15.13).
 
 Installation relies on the **luarocks** package manager.
 

--- a/examples/introduction.dj
+++ b/examples/introduction.dj
@@ -28,7 +28,7 @@ Yet, these options remain available under the hood for those seeking a blend of 
 
 ### Standard installation
 
-This module collection requires SILE v0.14 (recommended: v0.15.10 or upper).
+This module collection requires SILE v0.15 (recommended: v0.15.13).
 
 Installation relies on the *luarocks* package manager.
 To install the latest version, you may use the provided “rockspec”:

--- a/examples/markdown-djot.bib
+++ b/examples/markdown-djot.bib
@@ -2,7 +2,7 @@
   title        = {The SILE Book},
   author       = {Cozens, Simon and Maclennan, Caleb and Nicole, Olivier and Willis, Didier},
   year         = {2025},
-  edition      = {version 0.15.10},
+  edition      = {version 0.15.13},
 }
 
 @book{sile:willis2021,

--- a/examples/sile-and-markdown-manual.silm
+++ b/examples/sile-and-markdown-manual.silm
@@ -10,7 +10,7 @@ metadata:
     - Pandoc
   authors: Didier Willis
   publisher: Omikhleia
-  pubdate: 2025-03-21
+  pubdate: 2025-08-29
   url: https://github.com/Omikhleia/markdown.sile
   copyright: © 2022–2025, Didier Willis.
   legal: |
@@ -44,7 +44,6 @@ sile:
   packages:
     - autodoc-resilient # REQUIRED FOR RESILIENT, do not use regular autodoc
     - dropcaps
-    - resilient.defn
     - resilient.poetry
 content:
   chapters:

--- a/inputters/djot.lua
+++ b/inputters/djot.lua
@@ -6,8 +6,6 @@
 -- @copyright License: MIT (c) 2023-2024 Omikhleia, Didier Willis
 -- @module inputters.djot
 --
-require("silex.ast") -- Compatibility layer
-
 local utils = require("packages.markdown.utils")
 local createCommand, createStructuredCommand
         = SU.ast.createCommand, SU.ast.createStructuredCommand
@@ -149,7 +147,7 @@ function Renderer:render_children (node)
       error("Djot content too deeply nested", 2)
     elseif err:find("paperSize") then
        -- HACK
-       -- SILE 0.14.16 is still unimaginative how to avoid crashing the outputter
+       -- SILE 0.15.13 is still unimaginative how to avoid crashing the outputter
        -- and SU.error raises another error in the process.
       SILE.scratch.caughterror = true
       error("", 2)

--- a/inputters/markdown.lua
+++ b/inputters/markdown.lua
@@ -5,8 +5,6 @@
 -- @copyright License: MIT (c) 2022-2024 Omikhleia, Didier Willis
 -- @module inputters.markdown
 --
-require("silex.ast")
-
 local utils = require("packages.markdown.utils")
 local createCommand, createStructuredCommand
         = SU.ast.createCommand, SU.ast.createStructuredCommand

--- a/inputters/pandocast.lua
+++ b/inputters/pandocast.lua
@@ -12,8 +12,6 @@
 -- @copyright License: MIT (c) 2022-2024 Omikhleia, Didier Willis
 -- @module inputters.pandocast
 --
-require("silex.ast") -- Compatibility layer
-
 local utils = require("packages.markdown.utils")
 local createCommand, createStructuredCommand
         = SU.ast.createCommand, SU.ast.createStructuredCommand

--- a/packages/djot/init.lua
+++ b/packages/djot/init.lua
@@ -1,7 +1,7 @@
 --- Djot native support for SILE
 --
 -- @copyright License: License: MIT (c) 2023 Omikhleia
--- @module packages.djot
+-- @classmod packages.djot
 --
 local base = require("packages.base")
 

--- a/packages/markdown/init.lua
+++ b/packages/markdown/init.lua
@@ -1,7 +1,7 @@
 --- Markdown native support for SILE
 --
 -- @copyright License: MIT (c) 2022 Omikhleia
--- @module packages.markdown
+-- @classmod packages.markdown
 --
 local base = require("packages.base")
 

--- a/packages/markdown/utils.lua
+++ b/packages/markdown/utils.lua
@@ -1,25 +1,24 @@
 --- A few utilities for the markdown / pandocast inputters
 --
+-- @copyright License: MIT (c) 2022 Omikhleia
+-- @module packages.markdown.utils
 --
-require("silex.ast") -- Compatibility layer
 local createCommand = SU.ast.createCommand
 local createStructuredCommand = SU.ast.createStructuredCommand
 
---- Some utility functions.
--- @section utils
-
---- Extract the extension from a file name
+--- Extract the extension from a file name.
 -- Assumes a POSIX-compliant name (with a slash as path separators).
---
--- tparam  string fname file name
--- treturn string file extension
+-- @tparam string fname File name
+-- @treturn string File extension
 local function getFileExtension (fname)
   return fname:match("[^/]+$"):match("[^.]+$")
 end
 
+--- Non-breakable space extraction from a string.
+-- It replaces them with an appropriate non-breakable inter-word space command.
+-- @tparam string str Input string
+-- @treturn string|table Filtered string or SILE AST table
 local function nbspFilter (str)
-  -- Non-breakable space extraction from a string, replacing them with an
-  -- appropriate non-breakable inter-word space.
   local t = {}
   for token in SU.gtoke(str, " ") do -- Warning, U+00A0 here.
     if(token.string) then
@@ -34,9 +33,9 @@ local function nbspFilter (str)
 end
 
 --- Check if a given class is present in the options.
----@param options table    Command options
----@param classname string Pseudo-class specifier
----@return boolean
+-- @tparam table options Command options
+-- @tparam string classname Pseudo-class specifier
+-- @treturn boolean
 local function hasClass (options, classname)
   -- N.B. we want a true boolean here
   if options.class and string.match(' ' .. options.class .. ' ',' '..classname..' ') then
@@ -46,8 +45,8 @@ local function hasClass (options, classname)
 end
 
 --- Find the first raw handler suitable for the given pseudo-class attributes.
----@param options table  Command options
----@return function|nil  Handler function (if found)
+-- @tparam table options Command options
+-- @treturn function|nil Handler function (if found)
 local function hasRawHandler (options)
   for name, handler in pairs(SILE.rawHandlers) do
     if hasClass(options, name) then
@@ -59,8 +58,9 @@ local function hasRawHandler (options)
 end
 
 --- Find the first embedder suitable for the given pseudo-class attributes.
----@param options table           Command options with class attribute (nil or list of comma-separated classes)
----@return string|nil, function   Embedder name and handler function (if found)
+-- @tparam table options Command options with class attribute (nil or list of comma-separated classes)
+-- @treturn string|nil Embedder name (if found)
+-- @treturn function|nil Embedder handler function (if applicable)
 local function hasEmbedHandler (options)
   if not options.class then
     return nil
@@ -96,7 +96,7 @@ local bsratiocache = {}
 
 --- Compute the baseline ratio for the current font.
 --- This is a ratio of the descender to the theoretical height of the font.
----@return number Descender ratio
+---@treturn number Descender ratio
 local function computeBaselineRatio ()
   local fontoptions = SILE.font.loadDefaults({})
   local bsratio = bsratiocache[SILE.font._key(fontoptions)]
@@ -110,11 +110,11 @@ local function computeBaselineRatio ()
 end
 
 --- Naive citation reference parser.
---- We only support a very simple syntax for now: "@key[, ]+[locator]"
---- Where the unique locator consists of a name and a value separated by spaces.
----@param str    string Citation string
----@param pos    table  Position object
----@return table  AST command
+-- We only support a very simple syntax for now: `@key[, ]+[locator]`,
+-- where the unique locator consists of a name and a value separated by spaces.
+-- @tparam string str Citation string
+-- @tparam[opt] table pos Position in the source (for error reporting)
+-- @treturn table AST for the citation command
 local function naiveCitations (str, pos)
   local refs = pl.stringx.split(str, ";")
   pl.tablex.transform(function (ref)

--- a/packages/pandocast/init.lua
+++ b/packages/pandocast/init.lua
@@ -1,7 +1,7 @@
 --- Pandoc JSON AST native support for SILE
 --
 -- @copyright License: MIT (c) 2022-2023 Omikhleia
--- @module packages.pandocast
+-- @classmod packages.pandocast
 --
 local base = require("packages.base")
 

--- a/rockspecs/markdown.sile-3.0.0-1.rockspec
+++ b/rockspecs/markdown.sile-3.0.0-1.rockspec
@@ -1,8 +1,9 @@
 rockspec_format = "3.0"
 package = "markdown.sile"
-version = "dev-1"
+version = "3.0.0-1"
 source = {
     url = "git+https://github.com/Omikhleia/markdown.sile.git",
+    tag = "v3.0.0",
 }
 description = {
   summary = "Native Markdown support for the SILE typesetting system.",
@@ -16,12 +17,12 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "embedders.sile",
-   "highlighter.sile",
-   "labelrefs.sile",
-   "ptable.sile",
-   "smartquotes.sile",
-   "textsubsuper.sile",
+   "embedders.sile >= 0.2.0",
+   "highlighter.sile >= 0.2.1",
+   "labelrefs.sile >= 0.1.0",
+   "ptable.sile >= 3.2.0",
+   "smartquotes.sile >= 1.0.0",
+   "textsubsuper.sile >= 1.2.0",
    "lunajson",
 }
 


### PR DESCRIPTION
Stop supporting older SILE 0.14.x and 0.15.y (y <= 12).
Remove dependency on the silex compatibility layer.
Remove some compatibility fallbacks for earlier versions of SILE.
Update in-code documentation to LDoc (rather than the VSCode emma-based stuff).

Closes #148 