### PR TITLE
feat(Djot): Add support Lua filters for altering the AST before processing

### DIFF
--- a/examples/custom-filter.lua
+++ b/examples/custom-filter.lua
@@ -1,0 +1,99 @@
+--- An example Lua filter for Djot.
+--
+-- This filter does two things in sequence:
+--
+--  - On both spans and strings, it re-maps some classes to custom styles.
+--  - On strings only, it transforms numbers with the class "siecle" into roman numerals with a superscript "e", as per French typographic conventions.
+--
+-- @license MIT
+-- @copyright (c) 2025 Omikhleia / Didier Willis
+
+-- luacheck: globals djot
+
+local CLASS2STYLE = {
+  software = "Software",
+  hardware = "Hardware",
+}
+
+local function classToStyle (e)
+  if e.attr and e.attr['class'] then
+    local styles = {}
+    local classes = pl.Set(pl.stringx.split(e.attr['class']))
+    for class, style in pairs(CLASS2STYLE) do
+      if classes[class] then
+        styles[#styles+1] = style
+        classes[class] = nil
+      end
+    end
+    if #styles > 0 then
+      if #styles > 1 then
+        SU.warn("Multiple styles implied by classes, using the first one '" .. styles[1] .. "'")
+      end
+      if e.attr['custom-style'] then
+        SU.warn("Ignoring custom-style '" .. e.attr['custom-style'] .. "' because class implies style '" .. styles[1] .. "'")
+      end
+      e.attr['custom-style'] = styles[1]
+      e.attr.class = table.concat(pl.Set.values(classes), " ") -- Unused classes are kept
+    end
+  end
+end
+
+local function numberToRoman (num)
+  local val = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 }
+  local syms = { "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i" }
+  local roman = ""
+  for i = 1, #val do
+    while num >= val[i] do
+      num = num - val[i]
+      roman = roman .. syms[i]
+    end
+  end
+  return roman
+end
+
+return {
+  -- A first filter that maps classes to custom styles on spans and strings.
+  -- Ex. [Pandoc]{.software} --> equivalent to [Pandoc]{custom-style="Software"}
+  {
+    span = function(e)
+      classToStyle(e)
+    end,
+    str = function(e)
+      classToStyle(e)
+    end,
+  },
+  -- A second filter that transforms numbers with the class "siecle" into small caps roman
+  -- numerals with a superscript "e", as per French typographic conventions.
+  -- Ex. 21{.siecle} --> equivalent to xxi{.smallcaps}^e^
+  -- It somewhat specific to French, and we should rather delegate to a SILE command,
+  -- but it's a good example of AST manipulation.
+  {
+    str = function(e)
+      if e.attr and e.attr['class'] and tonumber(e.text) then
+        local classes = pl.Set(pl.stringx.split(e.attr['class']))
+        if not classes["siecle"] then
+          return -- Nothing to do
+        end
+        -- Unused classes are kept
+        classes["siecle"] = nil
+        e.attr['class'] = table.concat(pl.Set.values(classes), " ")
+        local num = tonumber(e.text)
+
+        -- Create the roman numeral
+        local century = djot.ast.new_node("str")
+        century.text = numberToRoman(num)
+        century.attr = djot.ast.new_attributes({ class = "smallcaps" })
+        -- Create the superscript "e"
+        local exp = djot.ast.new_node("str")
+        exp.text = num == 1 and "er" or "e"
+        -- Create the superscript node
+        local super = djot.ast.new_node("superscript")
+        super.children = { exp }
+        -- Transform the original str node into a span
+        e.tag = "span"
+        e.text = nil
+        e.children = { century, super }
+      end
+    end,
+  }
+}

--- a/examples/sile-and-djot.dj
+++ b/examples/sile-and-djot.dj
@@ -2,7 +2,7 @@
 
 > "Djot (/dʒɑt/) is a light markup syntax.
 > It derives most of its features from commonmark, but it fixes a few things
-> that make ommonmark's syntax complex and difficult to parse efficiently.
+> that make commonmark's syntax complex and difficult to parse efficiently.
 > It is also much fuller-featured (...)"
 ^ From the [Djot website](https://djot.net/).
 
@@ -36,7 +36,7 @@ The core concepts in Djot mirror those of Markdown, featuring inline and block e
 
   All ASCII punctuation characters (even those that have no special meaning in Djot) may be "backslash-escaped."
   Thus, `\*` is parsed and rendered as a literal \* character.
-  Backslashes before characters other than ASCII punctuation characters are just treated as literal backslashes, except before a newline, and a space (or a tab) character.
+  Backslashes before other characters are treated as literal backslashes, except before a newline, and a space (or a tab) character.
   We will get back to this later.
 
 : Inline elements
@@ -61,13 +61,13 @@ The core concepts in Djot mirror those of Markdown, featuring inline and block e
 
 ## Attributes
 
-Actually, let's start with attributes, as they have the same general syntax for both inline and block elements.
+Let's start with attributes, as they have the same general syntax for both inline and block elements.
 
 Attributes are put inside curly braces.
-On inline elements, attributes are placed immediately after the element they are attached to, with no intervening whitespace.
+On inline elements, they are placed immediately after the element they are attached to, with no intervening whitespace.
 They may contain line breaks, and may be "stacked," in which case they are combined.
 
-To attach attributes to a block-level element, put the attributes on the line immediately before the block.
+To attach attributes to a block-level element, put them on the line immediately before the block.
 Block attributes have the same syntax as inline attributes, but they must fit on one line.
 Repeated attribute specifiers can also be used, and the attributes accumulate.
 
@@ -76,6 +76,7 @@ Inside the curly braces, the following syntax is possible:
  - `#foo` specifies an identifier, for referencing purposes.
 
    An element may have only one identifier; if multiple identifiers are given, the last one is used.
+   Identifiers shall be unique.
 
  - `.foo` specifies a class, for styling purposes.
 
@@ -83,11 +84,15 @@ Inside the curly braces, the following syntax is possible:
 
  - `key="value"` or `key=value` specifies a key-value attribute.
 
-   Quotes are not needed when the value consists entirely of ASCII alphanumeric characters or `_` or `:` or `-`. Backslash escapes may be used inside quoted values.
+   Quotes are not needed when the value consists of ASCII alphanumeric characters or `_` or `:` or `-`. Backslash escapes may be used inside quoted values.
 
  - `?foo` and `!foo` specify a condition.
 
     This is an extension specific to this converter, see §[](#djot-conditional-attributes).
+
+- `:foo` and `:foo=value` specify an index entry.
+
+   This is an extension specific to this converter, see §[](#djot-index-entries-custom).
 
 ## Inline elements
 
@@ -226,7 +231,7 @@ You might notice a small difference between 2^10^{fake=false} and 2^10^{fake=tru
 ```
 :::
 
-There is another, likely more important, implication.
+There is another, more important, implication.
 This converter assumes that the content of a superscript or subscript consists of text, as it tries to use font features or text scaling techniques to render it.
 
 [^djot-textsubsuper]: Refer to the *textsubsuper* package for details.
@@ -414,7 +419,6 @@ Another link to [the SILE website][sile].
 [sile]: https://sile-typesetter.org/
 
 The reference label should be defined somewhere in the document.
-If the label is empty, then the link text is taken to be the reference label as well as the link text.
 
 {#djot-cross-references}
 #### Cross-references
@@ -1314,7 +1318,7 @@ This is SILE and Djot at their best{custom-style="strong"}!
 That's a fairly contrived way to obtain a bold text, but you get the underlying general idea.
 This is one of the ways to use SILE commands in Djot.
 While you could invoke _any_ SILE command with this feature, we recommend, though, to restrict it to styling.
-Another more powerful way to leverage Djot with SILE’s full processing capabilities, and benefit from the best of both worlds, is to use the "raw" annotations, described in §[](#djot-raw-inlines) and §[](#djot-raw-blocks).
+Another more powerful way to leverage Djot with SILE’s full processing capabilities, and benefit from the best of both worlds, is to use the "raw" annotations, described in §[](#djot-raw-inlines) and §[](#djot-raw-blocks); or filters, discussed in §[](#djot-configuration).
 
 
 ### Templates and variable substitution
@@ -1322,23 +1326,27 @@ Another more powerful way to leverage Djot with SILE’s full processing capabil
 [^:pumpernickel:]: Herbert _"Froggie"_ Pumpernickel{.smallcaps .nobreak}
 
 Let's now pretend that you are writing an essay about some fictitious :pumpernickel:.
+At this point, you know how to typeset that name in Djot syntax:
 
-From the previous sections, you know how to typeset that name in Djot syntax:
-`Herbert _"Froggie"_ Pumpernickel{.smallcaps .nobreak}`.
+{custom-style=CodeBlock}
+:::
+```
+Herbert _"Froggie"_ Pumpernickel{.smallcaps .nobreak}
+```
+:::
 
 So far, so good...
 But your problem is that this long name will appear a lot of times.
 Repeating it is tedious and error-prone.
 Would you appreciate defining it as a replaceable variable going by a much simpler name?
 
-Well, Djot has the notion of a "symbol", a keyword surrounded by colon signs (§[](#djot-symbols)).
-Although it was initially provisioned for "emojis", the default interpretation is now left to the rendering engine.
+Djot has the notion of a "symbol", a keyword surrounded by colon signs (§[](#djot-symbols)).
+The interpretation of such symbols is left to the rendering engine.
+This converter uses them in non-conventional ways.
 
-This converter for SILE is focussed on producing print-quality books, where so-called emojis play little part.
-We are therefore going to use those symbols in a non-conventional way.
 Back to our initial question, what if you could just type `:pumpernickel:` and have it automatically expanded?
 
-Since it's possible to have unused footnote definitions, let's craft one as shown hereafter, with its reference identifier being the same as our targeted variable.
+It’s possible to define footnotes without ever using them, so let's first craft one here, with same reference identifier as our target variable.
 
 {custom-style=CodeBlock}
 :::
@@ -1347,7 +1355,8 @@ Since it's possible to have unused footnote definitions, let's craft one as show
 ```
 :::
 
-When encountering a symbol, this converter looks for such a footnote and expands its content.
+When encountering a symbol, the converter looks for such a footnote and expands its content.
+
 It works with inline elements as shown above, but also with full blocks, provided the symbol is the only element in a paragraph of its own.
 Of course, these pseudo-footnotes[^djot-pseudo-footnotes] can in turn contain symbols, which get replaced too.
 
@@ -1441,11 +1450,11 @@ Optionally, an `indexed-⟨index⟩` attribute may be provided to define the tex
 ```
 :::
 
+{#djot-index-entries-custom}
 #### Shortcut syntax for indexing entries
 
 The syntax above is fully valid Djot and thus portable to other converters.
 However, it tends to be somewhat verbose and less than _lightweight_ in practice.
-
 For convenience, our Djot implementation also supports a more compact, non-standard syntax that is easier to type.
 
 {custom-style=CodeBlock}
@@ -1494,3 +1503,11 @@ For document classes supporting it (in particular, the *resilient* book class), 
 \include[src=somefile.dj, shift_headings=-1]
 ```
 :::
+
+For developers, the converter also accepts a `filter` option, whose value is the name of a Lua script (with or without the `.lua` extension).
+This script is loaded in a sandboxed environment and must return a table of filters in the form expected by the **djot.lua** library.
+
+Filters traverse the Djot AST and rewrite it, following the transformation rules you define.
+They can be useful to customize the conversion process in arbitrary ways --- adding features, modifying formatting, or transforming content structure in ways this converter doesn't provide out of the box.
+
+In other terms, in addition to raw annotations, custom styles and programmatic symbols, filters are another way to adapt this converter to your specific needs.

--- a/examples/sile-and-markdown.md
+++ b/examples/sile-and-markdown.md
@@ -1311,6 +1311,14 @@ This is one of the ways to use SILE commands in Djot.
 While you could invoke _any_ SILE command with this feature, we recommend, though, to restrict it to styling.
 Another more powerful way to leverage Djot with SILE’s full processing capabilities, and benefit from the best of both worlds, is to use the "raw" annotations, described in §[](#markdown-raw-inlines) and §[](#markdown-raw-blocks).
 
+::: {custom-style=Difference}
+![](./examples/manicule.svg){height=1.3ex} **Main differences with Djot**
+
+ - Only works on divs and spans (versus almost any element in Djot).
+
+:::
+
+
 ### Index entries
 
 Markdown does not provide a built-in syntax for marking index entries within the text.

--- a/packages/markdown/utils.lua
+++ b/packages/markdown/utils.lua
@@ -1,13 +1,15 @@
 --- A few utilities for the markdown / pandocast inputters
 --
--- @copyright License: MIT (c) 2022 Omikhleia
+-- @copyright License: MIT (c) 2022-2025 Omikhleia
 -- @module packages.markdown.utils
 --
 local createCommand = SU.ast.createCommand
 local createStructuredCommand = SU.ast.createStructuredCommand
 
 --- Extract the extension from a file name.
+--
 -- Assumes a POSIX-compliant name (with a slash as path separators).
+--
 -- @tparam string fname File name
 -- @treturn string File extension
 local function getFileExtension (fname)
@@ -15,7 +17,9 @@ local function getFileExtension (fname)
 end
 
 --- Non-breakable space extraction from a string.
+--
 -- It replaces them with an appropriate non-breakable inter-word space command.
+--
 -- @tparam string str Input string
 -- @treturn string|table Filtered string or SILE AST table
 local function nbspFilter (str)
@@ -33,6 +37,7 @@ local function nbspFilter (str)
 end
 
 --- Check if a given class is present in the options.
+--
 -- @tparam table options Command options
 -- @tparam string classname Pseudo-class specifier
 -- @treturn boolean
@@ -45,6 +50,7 @@ local function hasClass (options, classname)
 end
 
 --- Find the first raw handler suitable for the given pseudo-class attributes.
+--
 -- @tparam table options Command options
 -- @treturn function|nil Handler function (if found)
 local function hasRawHandler (options)
@@ -58,6 +64,7 @@ local function hasRawHandler (options)
 end
 
 --- Find the first embedder suitable for the given pseudo-class attributes.
+--
 -- @tparam table options Command options with class attribute (nil or list of comma-separated classes)
 -- @treturn string|nil Embedder name (if found)
 -- @treturn function|nil Embedder handler function (if applicable)
@@ -95,8 +102,10 @@ local metrics = require("fontmetrics")
 local bsratiocache = {}
 
 --- Compute the baseline ratio for the current font.
---- This is a ratio of the descender to the theoretical height of the font.
----@treturn number Descender ratio
+--
+-- This is a ratio of the descender to the theoretical height of the font.
+--
+-- @treturn number Descender ratio
 local function computeBaselineRatio ()
   local fontoptions = SILE.font.loadDefaults({})
   local bsratio = bsratiocache[SILE.font._key(fontoptions)]
@@ -110,8 +119,10 @@ local function computeBaselineRatio ()
 end
 
 --- Naive citation reference parser.
+--
 -- We only support a very simple syntax for now: `@key[, ]+[locator]`,
 -- where the unique locator consists of a name and a value separated by spaces.
+--
 -- @tparam string str Citation string
 -- @tparam[opt] table pos Position in the source (for error reporting)
 -- @treturn table AST for the citation command
@@ -143,6 +154,72 @@ local function naiveCitations (str, pos)
   return createStructuredCommand("cites", {}, refs, pos)
 end
 
+--- A sandboxed loadfile implementation.
+--
+-- Load and run a Lua file in a restricted environment.
+--
+-- @tparam string filename File name
+-- @tparam[opt] table env Additional environment entries
+-- @treturn unknown|nil Loaded chunk
+-- @treturn string|nil Error message
+local function sandboxedLoadfile(filename, env)
+  local envbase = {
+    -- Handy for debugging: print, SU logging functions, pl.pretty.dump.
+    -- Handy for table and string manipulations: table, pl.tablex, string, pl.stringx, pl.List, pl.Map, pl.Set.
+    print = print,
+    SU = {
+      debug = SU.debug,
+      error = SU.error,
+      warn = SU.warn,
+    },
+    pl = {
+      pretty = {
+        dump = function (data) pl.pretty.dump(data) end -- To avoid the second unsafe argument
+      },
+      tablex = pl.tablex,
+      stringx = pl.stringx,
+      List = pl.List,
+      Map = pl.Map,
+      Set = pl.Set,
+    },
+    table = table,
+    string = string,
+    -- And a few basic safe functions...
+    math = math,
+    ipairs = ipairs,
+    pairs = pairs,
+    type = type,
+    tostring = tostring,
+    tonumber = tonumber,
+    next = next,
+    error = error,
+    pcall = pcall,
+  }
+  env = pl.tablex.union(envbase, env or {}, true)
+  local f, err
+  -- Load in a sandboxed environment:
+  -- Strategies differ between Lua 5.1 and later versions.
+  if _VERSION == "Lua 5.1" then
+    f, err = loadfile(filename)
+    if not f then
+      return nil, err
+    end
+    -- luacheck: push globals setfenv
+    setfenv(f, env)
+    -- luacheck: pop
+  else
+    f, err = loadfile(filename, "t", env)
+    if not f then
+      return nil, err
+    end
+  end
+  -- Run the chunk in protected mode
+  local ok, res = pcall(f)
+  if not ok then
+    return nil, res end
+  return res
+end
+
 --- @export
 return {
   getFileExtension = getFileExtension,
@@ -152,4 +229,5 @@ return {
   hasEmbedHandler = hasEmbedHandler,
   computeBaselineRatio = computeBaselineRatio,
   naiveCitations = naiveCitations,
+  sandboxedLoadfile = sandboxedLoadfile,
 }

--- a/rockspecs/markdown.sile-3.1.0-1.rockspec
+++ b/rockspecs/markdown.sile-3.1.0-1.rockspec
@@ -1,0 +1,62 @@
+rockspec_format = "3.0"
+package = "markdown.sile"
+version = "3.1.0-1"
+source = {
+    url = "git+https://github.com/Omikhleia/markdown.sile.git",
+    tag = "v3.1.0",
+}
+description = {
+  summary = "Native Markdown support for the SILE typesetting system.",
+  detailed = [[
+    This package set for the SILE typesetting system provides a complete redesign
+    of the native Markdown support for SILE, with a great set of Pandoc-like
+    extensions and plenty of extra goodies.
+  ]],
+  homepage = "https://github.com/Omikhleia/markdown.sile",
+  license = "MIT",
+}
+dependencies = {
+   "lua >= 5.1",
+   "embedders.sile >= 0.2.0",
+   "highlighter.sile >= 0.2.1",
+   "labelrefs.sile >= 0.1.0",
+   "ptable.sile >= 3.2.0",
+   "smartquotes.sile >= 1.0.0",
+   "textsubsuper.sile >= 1.2.0",
+   "lunajson",
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      ["sile.classes.markdown"]           = "classes/markdown.lua",
+      ["sile.inputters.markdown"]         = "inputters/markdown.lua",
+      ["sile.inputters.pandocast"]        = "inputters/pandocast.lua",
+      ["sile.inputters.djot"]             = "inputters/djot.lua",
+      ["sile.packages.markdown"]          = "packages/markdown/init.lua",
+      ["sile.packages.markdown.cmbase"]   = "packages/markdown/cmbase.lua",
+      ["sile.packages.markdown.commands"] = "packages/markdown/commands.lua",
+      ["sile.packages.markdown.utils"]    = "packages/markdown/utils.lua",
+      ["sile.packages.pandocast"]         = "packages/pandocast/init.lua",
+      ["sile.packages.djot"]              = "packages/djot/init.lua",
+
+      ["sile.lunamark"]                 = "lua-libraries/lunamark.lua",
+      ["sile.lunamark.entities"]        = "lua-libraries/lunamark/entities.lua",
+      ["sile.lunamark.reader"]          = "lua-libraries/lunamark/reader.lua",
+      ["sile.lunamark.reader.markdown"] = "lua-libraries/lunamark/reader/markdown.lua",
+      ["sile.lunamark.util"]            = "lua-libraries/lunamark/util.lua",
+      ["sile.lunamark.writer"]          = "lua-libraries/lunamark/writer.lua",
+      ["sile.lunamark.writer.generic"]  = "lua-libraries/lunamark/writer/generic.lua",
+      ["sile.lunamark.writer.html"]     = "lua-libraries/lunamark/writer/html.lua",
+      ["sile.lunamark.writer.html5"]    = "lua-libraries/lunamark/writer/html5.lua",
+
+      ["sile.djot"]                     = "lua-libraries/djot.lua",
+      ["sile.djot.attributes"]          = "lua-libraries/djot/attributes.lua",
+      ["sile.djot.json"]                = "lua-libraries/djot/json.lua",
+      ["sile.djot.block"]               = "lua-libraries/djot/block.lua",
+      ["sile.djot.inline"]              = "lua-libraries/djot/inline.lua",
+      ["sile.djot.html"]                = "lua-libraries/djot/html.lua",
+      ["sile.djot.ast"]                 = "lua-libraries/djot/ast.lua",
+      ["sile.djot.filter"]              = "lua-libraries/djot/filter.lua",
+   }
+}


### PR DESCRIPTION
A proposal for "native" support for Djot AST filters (as proposed by [**djot.lua**](https://github.com/jgm/djot.lua)), exposed as a "filter" option on our Djot inputter.

Such filters allow to alter the Djot AST before feeding it to our renderer.

Out-of-the-box example use from a (resilient) master document -- It's a bit tedious as the master document is format-agnostic (so one would have to repeat this on each file), but it works :)[^1]

```
masterfile: 1.0
metadata:
  title: Some book
font:
  family: Libertinus Serif
  size: 12pt
language: en
sile:
  options:
    papersize: 6in x 9in
    layout: ateliers demiluxe
content:
  chapters:
    - file: chapters/something.dj # <--- explicit full object syntax instead of the short string syntax
      options:
        filter: examples/custom-filter # <--- ... So we can pass our custom filter as option
```

An example filter (`examples/custom-filter.lua`) is included in the PR.

Inspired by @pekkavaa 's discussion #155 

[^1]: Likewise, in bare SIL language, `\include[src=somefile.dj, filter=examples/custom-filter]` should work. I haven't checked, but it really should.
